### PR TITLE
Add manuals directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+manuals/*
+!manuals/README.md

--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ By default the parameters in `MAIN.py` define a single cycle with 16.21&ndash;16
 charging at 5&nbsp;A and a discharge down to 11&nbsp;V. Adjust them as needed for your
 test setup.
 
+
+## Manufacturer Programming Manuals
+
+A `manuals/` directory is provided for storing manufacturer documentation such as programming manuals.
+Add any PDF or reference files you need for the hardware here. The folder is ignored by Git so large documents won't be committed.

--- a/manuals/README.md
+++ b/manuals/README.md
@@ -1,0 +1,3 @@
+# Programming Manuals
+
+Place manufacturer programming manuals here. This folder is ignored by version control so you can add PDF or other documentation files for reference.


### PR DESCRIPTION
## Summary
- create `manuals` folder for storing manufacturer documentation
- allow only `README.md` in `manuals` to be tracked
- document the location in project README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688766f76d308325aa6e75eb86253632