### PR TITLE
Improve README with SCPI command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,47 @@ pip install pyvisa pandas openpyxl matplotlib tabulate
 python MAIN.py
 ```
 
-By default the parameters in `MAIN.py` define a single cycle with 16.21&ndash;16.4 V
-charging at 5&nbsp;A and a discharge down to 11&nbsp;V. Adjust them as needed for your
-test setup.
+By default the parameters in `MAIN.py` define a single cycle with
+16.21&ndash;16.4&nbsp;V charging at 5&nbsp;A and a discharge down to 11&nbsp;V.
+Adjust them as needed for your test setup.
+
+### Main parameters
+
+The top of `MAIN.py` contains constants used to configure a test run:
+
+| Variable | Default | Units |
+| --- | --- | --- |
+| `CHARGE_VOLT_START` | `16.21` | V |
+| `CHARGE_VOLT_END` | `16.4` | V |
+| `CHARGE_CURRENT_MAX` | `5.0` | A |
+| `DCHARGE_VOLT_MIN` | `11.0` | V |
+| `DCHARGE_CURRENT_MAX` | `1` | A |
+| `CHARGE_VOLT_PROT` | `20` | V |
+| `CHARGE_CURRENT_PROT` | `10` | A |
+| `CHARGE_POWER_PROT` | `2000` | W |
+| `SLEW_VOLT` | `0.1` | V/ms |
+| `SLEW_CURRENT` | `0.1` | A/ms |
+| `LEADIN_TIME` | `1` | s |
+| `CHARGE_TIME` | `5` | s |
+| `DCHARGE_TIME` | `5` | s |
+| `NUM_CYCLES` | `1` | &ndash; |
+
+Refer to the device programming manuals for the meaning of each setting.
 
 
 ## Manufacturer Programming Manuals
 
-A `manuals/` directory is provided for storing manufacturer documentation such as programming manuals.
-Add any PDF or reference files you need for the hardware here. The folder is ignored by Git so large documents won't be committed.
+The `manuals/` directory contains the official programming references used by
+the scripts:
+
+- `UM-63600 DC Load - v2.6 012021.pdf` – operating and programming manual for
+  the Chroma 63600 electronic load.
+- `62000P Operating Programming Manual 1704 - CSS.pdf` – programming manual for
+  the Chroma 62000P power supply.
+
+Consult these documents for the full list of SCPI commands and parameter ranges.
+Additional manuals can be placed in this folder; it is normally excluded from
+version control except for small README files.
+
+SCPI command mappings used by the driver classes are summarized in
+`scpi_commands.py` for quick reference when developing new tests.

--- a/scpi_commands.py
+++ b/scpi_commands.py
@@ -1,0 +1,95 @@
+# scpi_commands.py
+# Support file providing SCPI command mappings for device driver methods.
+# Designed for use by OpenAI Codex for code completion and reference.
+
+# PowerSupplyController SCPI mappings
+POWER_SUPPLY_COMMANDS = {
+    "checkDeviceConnection": "*IDN?",
+    "setVoltage": "SOUR:VOLT {volts}",
+    "setVoltageLimMax": "SOUR:VOLT:LIMIT:HIGH {volts}",
+    "setVoltageLimMin": "SOUR:VOLT:LIMIT:LOW {volts}",
+    "setVoltageProt": "SOUR:VOLT:PROT:HIGH {volts}",
+    "setVoltageSlew": "SOUR:VOLT:SLEW {volts}",
+    "setCurrent": "SOUR:CURR {amps}",
+    "setCurrentLimMax": "SOUR:CURR:LIMIT:HIGH {amps}",
+    "setCurrentLimMin": "SOUR:CURR:LIMIT:LOW {amps}",
+    "setCurrentProt": "SOUR:CURR:PROT:HIGH {amps}",
+    "setCurrentSlew": "SOUR:CURR:SLEW {amps}",
+    "setPowerProt": "SOUR:POW:PROT:HIGH {watts}",
+    "getVoltage": "FETCH:VOLT?",
+    "getCurrent": "FETCH:CURR?",
+    "getPower": "FETCH:POW?",
+    "startOutput": "CONF:OUTP ON",
+    "stopOutput": "CONF:OUTP OFF",
+    "chargeCC": [
+        "CONF:OUTP OFF",
+        "SOUR:VOLT MAX",
+        "SOUR:CURR {amps}",
+        "CONF:OUTP ON"
+    ],
+    "chargeCV": [
+        "CONF:OUTP OFF",
+        "SOUR:VOLT {volts}",
+        "CONF:OUTP ON"
+    ],
+    "chargeCP": [
+        "CONF:OUTP OFF",
+        "PROG:CP:POW {watts}",
+        "CONF:OUTP ON"
+    ],
+}
+
+# ElectronicLoadController SCPI mappings
+ELECTRONIC_LOAD_COMMANDS = {
+    "__init__": [
+        "CHAN 1",
+        "CHAN:ACT 1"
+    ],
+    "startDischarge": "LOAD ON",
+    "stopDischarge": "LOAD OFF",
+    "setCCLmode": "MODE CCL",
+    "setCCMmode": "MODE CCM",
+    "setCCcurrentL1": "CURR:STAT:L1 {amps}",
+    "setCCcurrentL1MAX": "CURR:STAT:L1 MAX {amps}",
+    "getCCcurrentL1MAX": "CURR:STAT:L1? MAX",
+    "getVoltage": "FETCH:VOLT?",
+    "getCurrent": "FETCH:CURR?",
+    "getPower": "FETCH:POW?",
+    "checkDeviceConnection": "*IDN?",
+    "setMaxCurrent": "VOLT:STAT:ILIM {amps}",
+    "dischargeCV": [
+        "LOAD:STAT:OFF",
+        "MODE CVH",
+        "VOLT:STAT:L1 {volts}",
+        "LOAD:STAT ON"
+    ],
+    "dischargeCC": [
+        "LOAD:STAT:OFF",
+        "MODE CCL",
+        "CURR:STAT:L1 {amps}",
+        "LOAD:STAT ON"
+    ],
+    "dischargeCP": [
+        "LOAD:STAT:OFF",
+        "MODE CPH",
+        "POW:STAT:L1 {watts}",
+        "LOAD:STAT ON"
+    ],
+}
+
+# MultimeterController SCPI mappings
+MULTIMETER_COMMANDS = {
+    "checkDeviceConnection": "*IDN?",
+    "getTemperature": "MEAS:TEMP?",
+    "getVolts": "MEAS:VOLT:DC?",
+    "getResistance": "MEAS:RES?",
+}
+
+# Instrument resource strings
+INSTRUMENT_RESOURCES = {
+    "power_supply": "USB0::0x1698::0x0837::011000000136::INSTR",
+    "electronic_load": "USB0::0x0A69::0x083E::000000000001::INSTR",
+    "multimeter": "USB0::0x1698::0x083F::TW00014586::INSTR",
+}
+
+# End of scpi_commands.py


### PR DESCRIPTION
## Summary
- create `scpi_commands.py` listing SCPI commands for each device class
- mention the new SCPI mapping file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688774e013c48325a6ab4f10df5e585c