### PR TITLE
Add actual capacity test

### DIFF
--- a/AlIonTestSoftwareDataManagement.py
+++ b/AlIonTestSoftwareDataManagement.py
@@ -22,6 +22,7 @@ class DataStorage:
         self.volts = []
         self.current = []
         self.power = []
+        self.capacity = []
 
     # Function to add time value
     def addTime(self, Mtime_sec: float):
@@ -34,6 +35,10 @@ class DataStorage:
     # Function to add current value
     def addCurrent(self, ampers: float):
         self.current.append(float('{:.4f}'.format(ampers)))
+
+    def addCapacity(self, ah: float):
+        """Store capacity value in ampere-hours."""
+        self.capacity.append(float('{:.4f}'.format(ah)))
 
     # Function for creating a table
     def createTable(self, testName, c_rate: float, cycleNr: int, temperature: float, timeInterval: float, chargeTime=0):
@@ -48,11 +53,16 @@ class DataStorage:
         # NaNs when creating the DataFrame.
         data = []
         # Fill the list with the results
+        include_capacity = len(self.capacity) == len(self.volts) and len(self.capacity) > 0
         for j in range(len(self.volts)):
             d = [float(j) * timeInterval, self.time[j],
                  self.volts[j], self.current[j], self.power[j]]
+            if include_capacity:
+                d.append(self.capacity[j])
             data.append(d)
         head = ["Time in seconds", "time", "Volts", "Current", "Power"]
+        if include_capacity:
+            head.append("Capacity")
         # Store the table in a text file
         today = date.today()
         try:
@@ -80,6 +90,7 @@ class DataStorage:
         self.volts = []
         self.current = []
         self.power = []
+        self.capacity = []
 
     def exportCSVFile(self, filePath, data, head):
         df = pd.DataFrame(data, columns=head)

--- a/MAIN.py
+++ b/MAIN.py
@@ -104,30 +104,38 @@ def main():
     parser.add_argument("--charge-time", type=int, default=CHARGE_TIME)
     parser.add_argument("--dcharge-time", type=int, default=DCHARGE_TIME)
     parser.add_argument("--num-cycles", type=int, default=NUM_CYCLES)
+    parser.add_argument("--actual-capacity-test", action="store_true",
+                        help="run actual capacity test")
+    parser.add_argument("--capacity-current", type=float, default=1.0,
+                        help="1C current in amperes")
 
     args = parser.parse_args()
 
-    settings = UPSSettings(
-        test_name=args.test_name,
-        temperature=args.temperature,
-        charge_volt_prot=args.charge_volt_prot,
-        charge_current_prot=args.charge_current_prot,
-        charge_power_prot=args.charge_power_prot,
-        charge_volt_start=args.charge_volt_start,
-        charge_volt_end=args.charge_volt_end,
-        charge_current_max=args.charge_current_max,
-        dcharge_volt_min=args.dcharge_volt_min,
-        dcharge_current_max=args.dcharge_current_max,
-        slew_volt=args.slew_volt,
-        slew_current=args.slew_current,
-        leadin_time=args.leadin_time,
-        charge_time=args.charge_time,
-        dcharge_time=args.dcharge_time,
-        num_cycles=args.num_cycles,
-    )
+    if args.actual_capacity_test:
+        tc = TestController()
+        tc.actual_capacity_test(args.capacity_current, args.temperature)
+    else:
+        settings = UPSSettings(
+            test_name=args.test_name,
+            temperature=args.temperature,
+            charge_volt_prot=args.charge_volt_prot,
+            charge_current_prot=args.charge_current_prot,
+            charge_power_prot=args.charge_power_prot,
+            charge_volt_start=args.charge_volt_start,
+            charge_volt_end=args.charge_volt_end,
+            charge_current_max=args.charge_current_max,
+            dcharge_volt_min=args.dcharge_volt_min,
+            dcharge_current_max=args.dcharge_current_max,
+            slew_volt=args.slew_volt,
+            slew_current=args.slew_current,
+            leadin_time=args.leadin_time,
+            charge_time=args.charge_time,
+            dcharge_time=args.dcharge_time,
+            num_cycles=args.num_cycles,
+        )
 
-    TObj = TestTypes()
-    TObj.runUPSTest(settings)
+        TObj = TestTypes()
+        TObj.runUPSTest(settings)
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ pip install pyvisa pandas openpyxl matplotlib tabulate
 python MAIN.py
 ```
 
+To perform a full capacity measurement instead of the default cycling test run:
+
+```bash
+python MAIN.py --actual-capacity-test --capacity-current 1.0
+```
+
+This charges the cell at 1C to **4.1&nbsp;V**, rests for one hour at
+20&nbsp;±&nbsp;2 °C and then discharges at 1C down to **2.75&nbsp;V** while
+recording the delivered ampere hours.
+
 By default the parameters in `MAIN.py` define a single cycle with
 16.21&ndash;16.4&nbsp;V charging at 5&nbsp;A and a discharge down to 11&nbsp;V.
 You can override any of these values using the command-line options


### PR DESCRIPTION
## Summary
- extend DataStorage with capacity handling
- implement `actual_capacity_test` procedure
- add CLI option `--actual-capacity-test`
- document new test in README
- remove old `Capacity_Test` method

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_688788d9020c8325b12a4b758e5c0221