### PR TITLE
Add battery efficiency test

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -338,6 +338,71 @@ class TestController:
         # Set the event to indicate that testing is finished
         self.event.set()
 
+    def efficiency_test(self, c_rate: float, num_cycles: int = 3) -> None:
+        """Run a simple efficiency test.
+
+        The battery is charged using a CC‑CV method to 4.1 V. Charging
+        switches from constant current at ``c_rate`` amps to constant voltage
+        at 4.1 V once the cell reaches that voltage. Charging stops when the
+        current drops below ``c_rate/25``. After charging the cell is
+        discharged at ``c_rate`` amps until 2.75 V.
+
+        Charge and discharge amp‑hours and watt‑hours are logged for each
+        cycle and the coulombic and energy efficiencies are calculated.  The
+        results from the third cycle are printed to stdout.
+        """
+
+        results = []
+        for cycle in range(1, num_cycles + 1):
+            ch_Ah = ch_Wh = 0.0
+            d_Ah = d_Wh = 0.0
+
+            # --- Charge (CC‑CV) ---
+            self.startPSOutput()
+            self.chargeCC(c_rate)
+            self.setVoltage(4.1)
+            in_cv = False
+            while True:
+                time.sleep(self.timeInterval)
+                v = self.getVoltagePSC()
+                c = self.getCurrentPSC()
+                ch_Ah += c * self.timeInterval / 3600.0
+                ch_Wh += v * c * self.timeInterval / 3600.0
+                if not in_cv and v >= 4.1:
+                    self.chargeCV(4.1)
+                    in_cv = True
+                if in_cv and c <= c_rate / 25.0:
+                    break
+            self.stopPSOutput()
+
+            # --- Discharge (1C) ---
+            self.stopDischarge()
+            self.setCCLmode()
+            self.setCCcurrentL1(c_rate)
+            self.startDischarge()
+            while True:
+                time.sleep(self.timeInterval)
+                v = self.getVoltageELC()
+                c = self.getCurrentELC()
+                d_Ah += c * self.timeInterval / 3600.0
+                d_Wh += v * c * self.timeInterval / 3600.0
+                if v <= 2.75:
+                    break
+            self.stopDischarge()
+
+            coul_eff = d_Ah / ch_Ah if ch_Ah else 0.0
+            en_eff = d_Wh / ch_Wh if ch_Wh else 0.0
+            results.append((ch_Ah, ch_Wh, d_Ah, d_Wh, coul_eff, en_eff))
+
+        if len(results) >= 3:
+            ch_Ah, ch_Wh, d_Ah, d_Wh, coul_eff, en_eff = results[2]
+            print(
+                f"Cycle 3 - Charged: {ch_Ah:.4f} Ah {ch_Wh:.4f} Wh, "
+                f"Discharged: {d_Ah:.4f} Ah {d_Wh:.4f} Wh, "
+                f"Coulombic eff.: {coul_eff:.4f}, Energy eff.: {en_eff:.4f}"
+            )
+
+
 
     def Capacity_Test(self, test_name: str, 
                    temperature: float, 

--- a/MAIN.py
+++ b/MAIN.py
@@ -104,8 +104,19 @@ def main():
     parser.add_argument("--charge-time", type=int, default=CHARGE_TIME)
     parser.add_argument("--dcharge-time", type=int, default=DCHARGE_TIME)
     parser.add_argument("--num-cycles", type=int, default=NUM_CYCLES)
+    parser.add_argument("--efficiency-test", action="store_true",
+                        help="run efficiency test instead of UPS test")
+    parser.add_argument("--c-rate", type=float, default=1.0,
+                        help="1C current in A for efficiency test")
+    parser.add_argument("--eff-cycles", type=int, default=3,
+                        help="number of cycles for efficiency test")
 
     args = parser.parse_args()
+
+    if args.efficiency_test:
+        tc = TestController()
+        tc.efficiency_test(args.c_rate, args.eff_cycles)
+        return
 
     settings = UPSSettings(
         test_name=args.test_name,

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ By default the parameters in `MAIN.py` define a single cycle with
 You can override any of these values using the command-line options
 documented below.
 
+To run the built-in efficiency test use the `--efficiency-test` flag. The
+1&nbsp;C current is specified with `--c-rate` (in amperes) and the number of
+cycles with `--eff-cycles`:
+
+```bash
+python MAIN.py --efficiency-test --c-rate 2.0
+```
+
 ### Main parameters
 
 The top of `MAIN.py` contains constants used to configure a test run:


### PR DESCRIPTION
## Summary
- implement new `efficiency_test` method supporting CC‑CV charge and 1C discharge
- add command-line options to run efficiency test
- document usage of efficiency test in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688788da79d08325b53ffd4de968b441