### PR TITLE
Add battery efficiency test

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -104,8 +104,19 @@ def main():
     parser.add_argument("--charge-time", type=int, default=CHARGE_TIME)
     parser.add_argument("--dcharge-time", type=int, default=DCHARGE_TIME)
     parser.add_argument("--num-cycles", type=int, default=NUM_CYCLES)
+    parser.add_argument("--efficiency-test", action="store_true",
+                        help="run efficiency test instead of UPS test")
+    parser.add_argument("--c-rate", type=float, default=1.0,
+                        help="1C current in A for efficiency test")
+    parser.add_argument("--eff-cycles", type=int, default=3,
+                        help="number of cycles for efficiency test")
 
     args = parser.parse_args()
+
+    if args.efficiency_test:
+        tc = TestController()
+        tc.efficiency_test(args.c_rate, args.eff_cycles)
+        return
 
     settings = UPSSettings(
         test_name=args.test_name,

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ By default the parameters in `MAIN.py` define a single cycle with
 You can override any of these values using the command-line options
 documented below.
 
+To run the built-in efficiency test use the `--efficiency-test` flag. The
+1&nbsp;C current is specified with `--c-rate` (in amperes) and the number of
+cycles with `--eff-cycles`. Each cycle's efficiency metrics are printed to
+the console, and the third cycle values are summarised at the end:
+
+```bash
+python MAIN.py --efficiency-test --c-rate 2.0
+```
+
 ### Main parameters
 
 The top of `MAIN.py` contains constants used to configure a test run:


### PR DESCRIPTION
## Summary
- implement new `efficiency_test` method supporting CC‑CV charge and 1C discharge
- add command-line options to run efficiency test
- document usage of efficiency test in README
- refine efficiency test output and return values

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_688788da79d08325b53ffd4de968b441