### PR TITLE
Return measured capacity

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -400,6 +400,8 @@ class TestController:
             "actual_capacity_test", current_1c, 0, temperature, self.timeInterval
         )
 
+        print(f"Accumulated capacity: {capacity:.3f} Ah")
         self.event.set()
+        return capacity
 
 

--- a/MAIN.py
+++ b/MAIN.py
@@ -113,7 +113,8 @@ def main():
 
     if args.actual_capacity_test:
         tc = TestController()
-        tc.actual_capacity_test(args.capacity_current, args.temperature)
+        capacity = tc.actual_capacity_test(args.capacity_current, args.temperature)
+        print(f"Measured capacity: {capacity:.3f} Ah")
     else:
         settings = UPSSettings(
             test_name=args.test_name,


### PR DESCRIPTION
## Summary
- show accumulated capacity after the discharge step
- display the measured capacity in MAIN when running `--actual-capacity-test`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_688794acaa008325a9baf9829ddcdee9