### PR TITLE
Remove stray debug prints

### DIFF
--- a/AlIonTestSoftwareDataManagement.py
+++ b/AlIonTestSoftwareDataManagement.py
@@ -74,15 +74,13 @@ class DataStorage:
             filePath = f"{data_dir}/{testName}_{c_rate}C_#{cycleNr + 1}_@{temperature}°C_" +\
             str(datetime.now().strftime("%d.%m.%y_%H;%M"))
             # Display the Path for debug purposes
-            print(abs)
+            print(abs_path)
             # Export to CSV file
             self.exportCSVFile(filePath, data, head)
             # Export to XLSX file
-            print(filePath)
-            print("filePath just now")
+            print(f"Saving results to {filePath}")
             self.exportXLSXFile(filePath, chargeTime, timeInterval)
-            print("export xlsx file just now")
-            print(f"Charge time is: {chargeTime}")
+            print(f"Charge time configured: {chargeTime}")
         except:
             print("Data storage failed, check file path")
         # Empty the result values
@@ -164,8 +162,6 @@ class DataStorage:
             # Create a list of Values to graph
             seconds = Reference(sheet, min_col=2, min_row=3,
                                 max_col=2, max_row=len(csvDataframe))
-            print(f"Charge time: {chargeTime}")
-            print(f"Time interval:  {timeInterval}")
             voltageCharging = Reference(sheet, min_col=3, min_row=3, max_col=3, max_row=int(
                 (float(chargeTime) * 60) / float(timeInterval)))
             currentCharging = Reference(sheet, min_col=4, min_row=3, max_col=4, max_row=int(

--- a/AlIonTestSoftwareDeviceDriversMock.py
+++ b/AlIonTestSoftwareDeviceDriversMock.py
@@ -57,7 +57,6 @@ class PowerSupplyControllerMock:
 
     # Functions to read realtime VOLTAGE, CURRENT and POWER from the power supply
     def getVoltage(self):
-        print("mock)")
         return randrange(int(self.Voltage_limmax * 10000000)) / 100000000
 
     def getCurrent(self):


### PR DESCRIPTION
## Summary
- replace `print(abs)` with `print(abs_path)` so the absolute path is shown
- clean up leftover debug messages
- silence mock driver voltage print

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688794a4ef0483258bbe0da77d7bf825