### PR TITLE
Add configurable charge/discharge currents for capacity test

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -565,12 +565,17 @@ class TestController:
 
         self.event.set()
 
-    def actual_capacity_test(self, current_1c: float, temperature: float = 20.0): #TODO current should be adjusted based on the charging or discharging
+    def actual_capacity_test(
+        self,
+        charge_current_1c: float,
+        discharge_current_1c: float,
+        temperature: float = 20.0,
+    ) -> float:
         """Perform an actual capacity test.
 
-        The procedure charges the cell at 1C to 4.1 V, rests for one hour and
-        then discharges at 1C down to 2.75 V while logging the cumulative
-        capacity.
+        The procedure charges the cell at ``charge_current_1c`` up to 4.1 V,
+        rests for one hour and then discharges at ``discharge_current_1c`` down
+        to 2.75 V while logging the cumulative capacity.
         """
 
         dataStorage = DataStorage()
@@ -578,12 +583,12 @@ class TestController:
 
         # ----- Charge step -----
         self.startPSOutput()
-        self.chargeCC(current_1c)
+        self.chargeCC(charge_current_1c)
         self.setVoltage(4.1)
 
         elapsed = 0.0
         capacity = 0.0
-        print("Charging to 4.1 V at 1C")
+        print(f"Charging to 4.1 V at {charge_current_1c} A")
         while True:
             time.sleep(self.timeInterval)
             elapsed += self.timeInterval
@@ -605,10 +610,10 @@ class TestController:
         # ----- Discharge step -----
         self.stopDischarge()
         self.setCCLmode() #TODO change to CCH mode ( has to be implemented in the ELC driver)
-        self.setCCcurrentL1(current_1c)
+        self.setCCcurrentL1(discharge_current_1c)
         self.startDischarge()
 
-        print("Discharging to 2.75 V at 1C")
+        print(f"Discharging to 2.75 V at {discharge_current_1c} A")
         while True:
             time.sleep(self.timeInterval)
             elapsed += self.timeInterval
@@ -624,7 +629,7 @@ class TestController:
 
         self.stopDischarge()
         dataStorage.createTable(
-            "actual_capacity_test", current_1c, 0, temperature, self.timeInterval
+            "actual_capacity_test", discharge_current_1c, 0, temperature, self.timeInterval
         )
 
         print(f"Accumulated capacity: {capacity:.3f} Ah")

--- a/MAIN.py
+++ b/MAIN.py
@@ -107,8 +107,10 @@ def main():
     parser.add_argument("--num-cycles", type=int, default=NUM_CYCLES)
     parser.add_argument("--actual-capacity-test", action="store_true",
                         help="run actual capacity test")
-    parser.add_argument("--capacity-current", type=float, default=1.0,
-                        help="1C current in amperes") #TODO current should be adjusted based on the charging or discharging
+    parser.add_argument("--capacity-charge-current", type=float, default=1.0,
+                        help="charge current for capacity test in amperes")
+    parser.add_argument("--capacity-discharge-current", type=float, default=1.0,
+                        help="discharge current for capacity test in amperes")
     parser.add_argument("--efficiency-test", action="store_true",
                         help="run efficiency test")
     parser.add_argument("--rate-characteristic-test", action="store_true",
@@ -132,7 +134,11 @@ def main():
 
     if args.actual_capacity_test:
         tc = TestController()
-        tc.actual_capacity_test(args.capacity_current, args.temperature)
+        tc.actual_capacity_test(
+            args.capacity_charge_current,
+            args.capacity_discharge_current,
+            args.temperature,
+        )
     elif args.efficiency_test:
         tc = TestController()
         tc.efficiency_test(
@@ -167,7 +173,11 @@ def main():
             args.pulse_duration,
             args.temperature,
         )
-        capacity = tc.actual_capacity_test(args.capacity_current, args.temperature)
+        capacity = tc.actual_capacity_test(
+            args.capacity_charge_current,
+            args.capacity_discharge_current,
+            args.temperature,
+        )
         print(f"Measured capacity: {capacity:.3f} Ah")
 
     else:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ python MAIN.py
 To perform a full capacity measurement instead of the default cycling test run:
 
 ```bash
-python MAIN.py --actual-capacity-test --capacity-current 1.0
+python MAIN.py --actual-capacity-test \
+  --capacity-charge-current 1.0 \
+  --capacity-discharge-current 1.0
 ```
 
 Additional tests can be invoked with the following flags:


### PR DESCRIPTION
## Summary
- allow separate charge/discharge currents in capacity test
- update CLI options and README accordingly

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888979f47f08325bbaad1fb1a1903ba