### PR TITLE
Add CCH mode support to battery test software

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -126,6 +126,10 @@ class TestController:
         # Switch to CC mode Medium Range (max 8 amper)
         self.electronicLoadController.setCCMmode()
 
+    def setCCHmode(self):
+        # Switch to CC mode High Range
+        self.electronicLoadController.setCCHmode()
+
     def setCCcurrentL1(self, amper: float):
         self.electronicLoadController.setCCcurrentL1(
             amper)  # Set the desired current of Channel L1
@@ -605,7 +609,7 @@ class TestController:
 
         # ----- Discharge step -----
         self.stopDischarge()
-        self.setCCLmode() #TODO change to CCH mode ( has to be implemented in the ELC driver)
+        self.setCCHmode()
         self.setCCcurrentL1(discharge_current_1c)
         self.startDischarge()
 

--- a/AlIonTestSoftwareDeviceDrivers.py
+++ b/AlIonTestSoftwareDeviceDrivers.py
@@ -143,6 +143,9 @@ class ElectronicLoadController:
     def setCCMmode(self):
         self.electronicLoad.write("MODE CCM") # Switch to CC mode Medium Range
 
+    def setCCHmode(self):
+        self.electronicLoad.write("MODE CCH") # Switch to CC mode High Range
+
     def setCCcurrentL1(self, amps):
         self.electronicLoad.write("CURR:STAT:L1 " + str(amps))  # Set the desired current of Channel L1
 

--- a/AlIonTestSoftwareDeviceDriversMock.py
+++ b/AlIonTestSoftwareDeviceDriversMock.py
@@ -116,6 +116,10 @@ class ElectronicLoadControllerMock:
         # Switch to CC mode Medium Range (max 8 amper)
         pass
 
+    def setCCHmode(self):
+        # Switch to CC mode High Range
+        pass
+
     def setCCcurrentL1(self, amper: float):
         # Set the desired current of Channel L1
         self.current_L1 = amper

--- a/scpi_commands.py
+++ b/scpi_commands.py
@@ -49,6 +49,7 @@ ELECTRONIC_LOAD_COMMANDS = {
     "stopDischarge": "LOAD OFF",
     "setCCLmode": "MODE CCL",
     "setCCMmode": "MODE CCM",
+    "setCCHmode": "MODE CCH",
     "setCCcurrentL1": "CURR:STAT:L1 {amps}",
     "setCCcurrentL1MAX": "CURR:STAT:L1 MAX {amps}",
     "getCCcurrentL1MAX": "CURR:STAT:L1? MAX",


### PR DESCRIPTION
## Summary
- implement `setCCHmode` in the electronic load driver and mock
- expose `setCCHmode` in `AlIonBatteryTestSoftware`
- map SCPI command `MODE CCH`
- use CCH discharge mode in `actual_capacity_test`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888b307048c832586b82bc0aa67182b