### PR TITLE
Add charge voltage option to capacity test

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -565,13 +565,15 @@ class TestController:
         self,
         charge_current_1c: float,
         discharge_current_1c: float,
+        charge_voltage: float = 4.1,
         temperature: float = 20.0,
     ) -> float:
         """Perform an actual capacity test.
 
-        The procedure charges the cell at ``charge_current_1c`` up to 4.1 V,
-        rests for one hour and then discharges at ``discharge_current_1c`` down
-        to 2.75 V while logging the cumulative capacity.
+        The procedure charges the cell at ``charge_current_1c`` up to
+        ``charge_voltage``, rests for one hour and then discharges at
+        ``discharge_current_1c`` down to 2.75 V while logging the cumulative
+        capacity.
         """
 
         dataStorage = DataStorage()
@@ -580,11 +582,11 @@ class TestController:
         # ----- Charge step -----
         self.startPSOutput()
         self.chargeCC(charge_current_1c)
-        self.setVoltage(4.1) # TODO replace magic number with a parameter
+        self.setVoltage(charge_voltage)
 
         elapsed = 0.0
         capacity = 0.0
-        print(f"Charging to 4.1 V at {charge_current_1c} A")
+        print(f"Charging to {charge_voltage} V at {charge_current_1c} A")
         while True:
             time.sleep(self.timeInterval)
             elapsed += self.timeInterval
@@ -594,7 +596,7 @@ class TestController:
             dataStorage.addVoltage(v)
             dataStorage.addCurrent(c)
             dataStorage.addCapacity(capacity)
-            if v >= 4.1: # TODO replace magic number with a parameter
+            if v >= charge_voltage:
                 break
 
         self.stopPSOutput()

--- a/MAIN.py
+++ b/MAIN.py
@@ -163,6 +163,7 @@ def main():
         tc.actual_capacity_test(
             args.capacity_charge_current,
             args.capacity_discharge_current,
+            args.charge_volt_end,
             args.temperature,
         )
     elif args.efficiency_test:
@@ -202,6 +203,7 @@ def main():
         capacity = tc.actual_capacity_test(
             args.capacity_charge_current,
             args.capacity_discharge_current,
+            args.charge_volt_end,
             args.temperature,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ To perform a full capacity measurement instead of the default cycling test run:
 ```bash
 python MAIN.py --actual-capacity-test \
   --capacity-charge-current 1.0 \
-  --capacity-discharge-current 1.0
+  --capacity-discharge-current 1.0 \
+  --charge-volt-end 4.1
 ```
 
 Additional tests can be invoked with the following flags:
@@ -91,7 +92,8 @@ python MAIN.py --config-file cell_profiles.json --profile YUASA
 
 Command-line options still override the values loaded from the profile.
 
-This charges the cell at 1C to **4.1&nbsp;V**, rests for one hour at
+This charges the cell at 1C up to the voltage specified by
+`--charge-volt-end` (default **4.1&nbsp;V**), rests for one hour at
 20&nbsp;±&nbsp;2 °C and then discharges at 1C down to **2.75&nbsp;V** while
 recording the delivered ampere hours.
 


### PR DESCRIPTION
## Summary
- extend `actual_capacity_test` with a `charge_voltage` argument
- pass the configured end charge voltage from `MAIN.py`
- mention the option in the README example

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888b3018ae083258ddfbcf96cdc2bf8