### PR TITLE
Add rest_time argument for capacity test

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -565,13 +565,15 @@ class TestController:
         self,
         charge_current_1c: float,
         discharge_current_1c: float,
+        rest_time: float = 3600.0,
         temperature: float = 20.0,
     ) -> float:
         """Perform an actual capacity test.
 
         The procedure charges the cell at ``charge_current_1c`` up to 4.1 V,
-        rests for one hour and then discharges at ``discharge_current_1c`` down
-        to 2.75 V while logging the cumulative capacity.
+        rests for ``rest_time`` seconds and then discharges at
+        ``discharge_current_1c`` down to 2.75 V while logging the cumulative
+        capacity.
         """
 
         dataStorage = DataStorage()
@@ -600,8 +602,8 @@ class TestController:
         self.stopPSOutput()
 
         # ----- Rest step -----
-        print("Resting for 1 hour")
-        time.sleep(3600) # TODO change to a parameter, 1hr is too much for some tests
+        print(f"Resting for {rest_time} seconds")
+        time.sleep(rest_time)
 
         # ----- Discharge step -----
         self.stopDischarge()

--- a/MAIN.py
+++ b/MAIN.py
@@ -163,6 +163,7 @@ def main():
         tc.actual_capacity_test(
             args.capacity_charge_current,
             args.capacity_discharge_current,
+            3600.0,
             args.temperature,
         )
     elif args.efficiency_test:
@@ -202,6 +203,7 @@ def main():
         capacity = tc.actual_capacity_test(
             args.capacity_charge_current,
             args.capacity_discharge_current,
+            3600.0,
             args.temperature,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ python MAIN.py --config-file cell_profiles.json --profile YUASA
 
 Command-line options still override the values loaded from the profile.
 
-This charges the cell at 1C to **4.1&nbsp;V**, rests for one hour at
-20&nbsp;±&nbsp;2 °C and then discharges at 1C down to **2.75&nbsp;V** while
-recording the delivered ampere hours.
+This charges the cell at 1C to **4.1&nbsp;V**, rests for a configurable
+period (default one hour) at 20&nbsp;±&nbsp;2 °C and then discharges at 1C
+down to **2.75&nbsp;V** while recording the delivered ampere hours.
 
 By default the parameters in `MAIN.py` define a single cycle with
 16.21&ndash;16.4&nbsp;V charging at 5&nbsp;A and a discharge down to 11&nbsp;V.


### PR DESCRIPTION
## Summary
- allow specifying a rest period in `actual_capacity_test`
- pass the new parameter from `MAIN.py`
- document configurable rest period in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888b30448b483259d374a3cbe365ed6