### PR TITLE
Restore lead-in voltage ramp

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -253,15 +253,17 @@ class TestController:
             while (datetime.now() < Cend_time):
                 # while Charging do the following
                 time.sleep(self.timeInterval)  # Wait between measurements
-                tmp = datetime.now()-ChargestartTime
-                # increases output voltage from charge_volt_start to charge_volt_end in leadin_time sec.
-                # if (tmp.total_seconds() < Lduration.seconds):
-                #    Lratio = tmp.total_seconds()/float(Lduration.seconds)
-                #    currentVolt=charge_volt_start+DeltaV*Lratio
-                #    if (currentVolt>charge_volt_end):
-                #        currentVolt=charge_volt_end
-                #    self.setVoltage(currentVolt)
-                #    print(currentVolt)
+                tmp = datetime.now() - ChargestartTime
+                # gradually ramp voltage from charge_volt_start to
+                # charge_volt_end during the lead-in period
+                if leadin_time > 0:
+                    ratio = min(tmp.total_seconds() / float(leadin_time), 1.0)
+                else:
+                    ratio = 1.0
+                currentVolt = charge_volt_start + DeltaV * ratio
+                if currentVolt > charge_volt_end:
+                    currentVolt = charge_volt_end
+                self.setVoltage(currentVolt)
 
                 # print(tmp.total_seconds())
                 # read the voltage from Power Supply - this is the applied voltage

--- a/MAIN.py
+++ b/MAIN.py
@@ -22,7 +22,9 @@ SLEW_VOLT: float = 0.1    # V/ms
 SLEW_CURRENT: float = 0.1    # A/ms
 
 # Timing (in seconds)
-LEADIN_TIME: int = 1    # s #TODO: fix the implementation of leadin time
+# Ramp duration for increasing the charge voltage from CHARGE_VOLT_START
+# to CHARGE_VOLT_END at the beginning of each cycle
+LEADIN_TIME: int = 1    # s
 
 CHARGE_TIME: int = 5    # s
 DCHARGE_TIME: int = 5   # s

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ The top of `MAIN.py` contains constants used to configure a test run:
 | `DCHARGE_TIME` | `5` | s |
 | `NUM_CYCLES` | `1` | &ndash; |
 
+`LEADIN_TIME` controls how long the power supply ramps from
+`CHARGE_VOLT_START` to `CHARGE_VOLT_END` at the beginning of each charge cycle.
+
 Refer to the device programming manuals for the meaning of each setting.
 
 ### Command-line options
@@ -143,7 +146,7 @@ common flags accepted by `MAIN.py` are listed below. Run
 | `--dcharge-current-max` | Maximum discharge current |
 | `--slew-volt` | Voltage slew rate in V/ms |
 | `--slew-current` | Current slew rate in A/ms |
-| `--leadin-time` | Lead-in delay before measurements |
+| `--leadin-time` | Time in seconds used to ramp the supply from the starting to the ending charge voltage |
 | `--charge-time` | Allowed charging time |
 | `--dcharge-time` | Allowed discharging time |
 | `--num-cycles` | Number of charge/discharge cycles |


### PR DESCRIPTION
## Summary
- reinstate ramp from `charge_volt_start` to `charge_volt_end` in `NEWupsTest`
- document ramp duration and remove stale TODO in `MAIN.py`
- describe `leadin_time` usage in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888b30ba6c483259890a94ef30a29ff