### PR TITLE
Fix voltage and current spelling

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -49,9 +49,9 @@ class TestController:
 
     # Defining basic functionality of all remote devices through the device controller
     #####  62000P Power supply #####
-    # Function for constant CURRENT charging, taking in current in ampers
-    def chargeCC(self, ampers):
-        self.powerSupplyController.chargeCC(ampers)
+    # Function for constant CURRENT charging, taking in current in amps
+    def chargeCC(self, amps):
+        self.powerSupplyController.chargeCC(amps)
 
     # Function for constant VOLTAGE charging, taking in voltage in volts
     def chargeCV(self, volts):

--- a/AlIonTestSoftwareDataManagement.py
+++ b/AlIonTestSoftwareDataManagement.py
@@ -24,12 +24,12 @@ class DataStorage:
         self.time.append(float('{:.4f}'.format(Mtime_sec)))
 
     # Function to add voltage value
-    def addVoltage(self, votls: float):
-        self.volts.append(float('{:.4f}'.format(votls)))
+    def addVoltage(self, volts: float):
+        self.volts.append(float('{:.4f}'.format(volts)))
 
     # Function to add current value
-    def addCurrent(self, ampers: float):
-        self.current.append(float('{:.4f}'.format(ampers)))
+    def addCurrent(self, amps: float):
+        self.current.append(float('{:.4f}'.format(amps)))
 
     def addMMVoltage(self, volts: float):
         self.mm_volts.append(float('{:.4f}'.format(volts)))

--- a/AlIonTestSoftwareDeviceDrivers.py
+++ b/AlIonTestSoftwareDeviceDrivers.py
@@ -79,14 +79,14 @@ class PowerSupplyController:
         return self.powerSupply.query("FETCH:POW?")
         
 
-    # Function for constant CURRENT charging, taking in current in ampers
-    def chargeCC (self, ampers : int):
+    # Function for constant CURRENT charging, taking in current in amps
+    def chargeCC (self, amps : int):
         # Turn of all output
         self.powerSupply.write("CONF:OUTP OFF")
         # Set the voltage amount to max
         self.powerSupply.write("SOUR:VOLT MAX")
         # Set desired current
-        self.powerSupply.write("SOUR:CURR " + str(ampers))
+        self.powerSupply.write("SOUR:CURR " + str(amps))
         # Turn on output
         self.powerSupply.write("CONF:OUTP ON")
 
@@ -103,7 +103,7 @@ class PowerSupplyController:
     def chargeCP(self, watts : int):
         # Turn of all output
         self.powerSupply.write("CONF:OUTP OFF")
-        # Set desired voltiage
+        # Set desired voltage
         self.powerSupply.write("PROG:CP:POW " + str(watts))
         # Turn on output
         self.powerSupply.write("CONF:OUTP ON")

--- a/AlIonTestSoftwareDeviceDriversMock.py
+++ b/AlIonTestSoftwareDeviceDriversMock.py
@@ -66,8 +66,8 @@ class PowerSupplyControllerMock:
         return randrange(int(self.Power_limmax * 10000000)) / 100000000
         
 
-    # Function for constant CURRENT charging, taking in current in ampers
-    def chargeCC (self, ampers : float):
+    # Function for constant CURRENT charging, taking in current in amps
+    def chargeCC (self, amps : float):
         pass
 
     # Function for constant VOLTAGE charging, taking in voltage in volts


### PR DESCRIPTION
## Summary
- correct misspelled parameter names `votls` and `ampers`
- update comments describing voltage/current arguments

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6888d59d73548325a5ded45f01cec40f