### PR TITLE
Add module and class docstrings

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -1,3 +1,5 @@
+"""Core routines for controlling UPS battery test sequences."""
+
 import time
 from datetime import datetime
 from datetime import timedelta
@@ -9,6 +11,7 @@ from AlIonTestSoftwareDataManagement import DataStorage
 
 # Class used to control test procedures
 class TestController:
+    """Coordinate power supply, load and measurement devices for tests."""
     # Indicates the number of seconds between each measurement
     timeInterval = 0.2
     # Variable for keeping track of the open circuit voltage of a full battery

--- a/AlIonTestSoftwareDataManagement.py
+++ b/AlIonTestSoftwareDataManagement.py
@@ -1,3 +1,5 @@
+"""Utilities for storing measurement data and exporting results."""
+
 import openpyxl
 from openpyxl.chart import ScatterChart, Reference, Series  # type: ignore
 # from openpyxl.chart.series import Series
@@ -8,6 +10,7 @@ import math
 
 
 class DataStorage:
+    """Collect measurement data and export it to CSV and XLSX."""
 
     def __init__(self) -> None:
         # Empty arrays for data

--- a/AlIonTestSoftwareDeviceDrivers.py
+++ b/AlIonTestSoftwareDeviceDrivers.py
@@ -1,7 +1,10 @@
+"""Device driver wrappers using NI-VISA to control test equipment."""
+
 import pyvisa
 
 # Class for communication with the NI-VISA driver to control the power supply
 class PowerSupplyController:
+    """Control a Chroma 62000P power supply via SCPI commands."""
     # Variable to keep the resource name of the power supply
     powerSupplyName = "USB0::0x1698::0x0837::011000000136::INSTR"
 
@@ -118,6 +121,7 @@ class PowerSupplyController:
 
 # Class for communication with the NI-VISA driver to control the electronic load
 class ElectronicLoadController:
+    """Interface to a Chroma 63600 electronic load for discharging cells."""
     # Variable to keep the resource name of the electronic load
     electronicLoadName = "USB0::0x0A69::0x083E::000000000001::INSTR"
 
@@ -209,6 +213,7 @@ class ElectronicLoadController:
 
 # Class for communication with the NI-VISA driver to control the multimeter
 class MultimeterController:
+    """Read measurements from a Chroma 51101 multimeter."""
     
     # Variable to keep the resource name of the mutimeter
     multimeterName = "USB0::0x1698::0x083F::TW00014586::INSTR"

--- a/AlIonTestSoftwareDeviceDriversMock.py
+++ b/AlIonTestSoftwareDeviceDriversMock.py
@@ -1,3 +1,5 @@
+"""Mock implementations of the device drivers for testing without hardware."""
+
 from random import randrange
 import tkinter
 

--- a/MAIN.py
+++ b/MAIN.py
@@ -1,3 +1,5 @@
+"""Command line interface for running UPS battery tests."""
+
 from dataclasses import dataclass
 import argparse
 import json

--- a/scpi_commands.py
+++ b/scpi_commands.py
@@ -1,3 +1,5 @@
+"""SCPI command mappings and instrument resource strings."""
+
 # scpi_commands.py
 # Support file providing SCPI command mappings for device driver methods.
 # Designed for use by OpenAI Codex for code completion and reference.


### PR DESCRIPTION
## Summary
- add short module-level docstrings to each python file
- document the TestController, DataStorage and device driver classes

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888d5a0142c832595ceb6a198892e8c