### PR TITLE
Prompt before using mock drivers

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -39,7 +39,15 @@ class TestController:
             # are not available.  The previous implementation exited before the
             # mock controllers were created which made running the software
             # without hardware impossible.
-            print("Connection not successful, using mock objects")
+            print("Connection not successful.")
+            answer = input(
+                "Devices not detected. Continue with mock drivers? [y/N]: "
+            ).strip().lower()
+            if answer not in ("y", "yes"):
+                raise SystemExit(
+                    "Aborting: no connection to hardware and user declined mock drivers"
+                )
+            print("Using mock objects")
             self.powerSupplyController = PowerSupplyControllerMock()
             self.electronicLoadController = ElectronicLoadControllerMock()
             self.multimeterController = MultimeterControllerMock()

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ pip install pyvisa pandas openpyxl matplotlib tabulate
 ```bash
 python MAIN.py
 ```
+   If no hardware connection is detected the program will ask whether to
+   continue using mock drivers.
 
 To perform a full capacity measurement instead of the default cycling test run:
 


### PR DESCRIPTION
## Summary
- ask the user before falling back to mock drivers if hardware is not found
- document this prompt in the README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888d8c4fff4832598309b2098f7f9bc