### PR TITLE
Use measured temperature in output filenames

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -399,9 +399,15 @@ class TestController:
             self.stopDischarge()  # Inactivate the electronic load
             # Discharging loop ends
 
-            # Create a table from the measurements made in this cycle (27.0 is the temperature - now kept fixed)
+            # Use multimeter temperature in filename when available
             dataStorage.createTable(
-                test_name, dcharge_current_max, cycleNumber, temperature, self.timeInterval, charge_time)
+                test_name,
+                dcharge_current_max,
+                cycleNumber,
+                temperature,
+                self.timeInterval,
+                charge_time,
+            )
 
         # Set the event to indicate that testing is finished
         self.event.set()

--- a/AlIonTestSoftwareDataManagement.py
+++ b/AlIonTestSoftwareDataManagement.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import os
 import pandas as pd
 import math
+import statistics
 
 
 class DataStorage:
@@ -124,8 +125,16 @@ class DataStorage:
             data_dir = f"{abs_path}/Data"
             # Ensure the output directory exists
             os.makedirs(data_dir, exist_ok=True)
-            filePath = f"{data_dir}/{testName}_{c_rate}C_#{cycleNr + 1}_@{temperature}°C_" +\
-            str(datetime.now().strftime("%d.%m.%y_%H;%M"))
+            if include_mm_temp:
+                avg_temp = statistics.mean(self.mm_temp)
+                file_temp = f"{avg_temp:.1f}"
+            else:
+                file_temp = f"{temperature}"
+
+            filePath = (
+                f"{data_dir}/{testName}_{c_rate}C_#{cycleNr + 1}_@{file_temp}°C_"
+                + str(datetime.now().strftime("%d.%m.%y_%H;%M"))
+            )
             # Display the Path for debug purposes
             print(abs_path)
             # Export to CSV file


### PR DESCRIPTION
## Summary
- when temperature from the multimeter is logged, compute the average and use it in generated filenames
- mention temperature source in UPS test comment

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888f0f67af48325910ad6ef6be7e5a3