### PR TITLE
Add safe keyboard interrupt handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,8 @@ python -m py_compile *.py
 ```
 
 at the repository root. This ensures all Python files compile cleanly.
+
+## Stopping a running test
+
+Press `Ctrl+C` while a test is active to abort safely. The program turns off
+all outputs and saves the results collected so far before exiting.


### PR DESCRIPTION
## Summary
- handle keyboard interrupts and add abort method
- safely stop running tests in MAIN
- document how to stop tests

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6888f5768e2c8325befe76731293005c