### PR TITLE
Add min_voltage parameter to capacity test

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -657,13 +657,14 @@ class TestController:
         discharge_current_1c: float,
         rest_time: float = 3600.0,
         charge_voltage: float = 4.1,
+        min_voltage: float = 2.75,
         temperature: float = 20.0,
     ) -> float:
         """Perform an actual capacity test.
 
         The procedure charges the cell at ``charge_current_1c`` up to ``charge_voltage``,
         rests for one hour and then discharges at ``discharge_current_1c`` down
-        to 2.75 V while logging the cumulative capacity.
+        to ``min_voltage`` V while logging the cumulative capacity.
         """
 
         dataStorage = DataStorage()
@@ -705,7 +706,7 @@ class TestController:
         self.setCCcurrentL1(discharge_current_1c)
         self.startDischarge()
 
-        print(f"Discharging to 2.75 V at {discharge_current_1c} A")
+        print(f"Discharging to {min_voltage} V at {discharge_current_1c} A")
         while True:
             time.sleep(self.timeInterval)
             elapsed += self.timeInterval
@@ -716,7 +717,7 @@ class TestController:
             dataStorage.addVoltage(v)
             dataStorage.addCurrent(c)
             dataStorage.addCapacity(capacity)
-            if v <= 2.75:
+            if v <= min_voltage:
                 break
 
         self.stopDischarge()

--- a/MAIN.py
+++ b/MAIN.py
@@ -200,6 +200,7 @@ def main():
             args.capacity_discharge_current,
             3600.0,
             charge_volt_end,
+            dcharge_volt_min,
             temperature,
         )
     elif args.efficiency_test:
@@ -241,6 +242,7 @@ def main():
             args.capacity_discharge_current,
             3600.0,
             charge_volt_end,
+            dcharge_volt_min,
             temperature,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")


### PR DESCRIPTION
## Summary
- extend `TestController.actual_capacity_test` with `min_voltage` parameter
- use the new parameter in logs and discharge loop
- update CLI calls to pass discharge voltage minimum

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6889f8bd5580832585f6ccf12b521d62