### PR TITLE
Support capacity defaults via JSON config

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -657,13 +657,14 @@ class TestController:
         discharge_current_1c: float,
         rest_time: float = 3600.0,
         charge_voltage: float = 4.1,
+        min_voltage: float = 2.75,
         temperature: float = 20.0,
     ) -> float:
         """Perform an actual capacity test.
 
         The procedure charges the cell at ``charge_current_1c`` up to ``charge_voltage``,
         rests for one hour and then discharges at ``discharge_current_1c`` down
-        to 2.75 V while logging the cumulative capacity.
+        to ``min_voltage`` while logging the cumulative capacity.
         """
 
         dataStorage = DataStorage()
@@ -705,7 +706,7 @@ class TestController:
         self.setCCcurrentL1(discharge_current_1c)
         self.startDischarge()
 
-        print(f"Discharging to 2.75 V at {discharge_current_1c} A")
+        print(f"Discharging to {min_voltage} V at {discharge_current_1c} A")
         while True:
             time.sleep(self.timeInterval)
             elapsed += self.timeInterval
@@ -716,7 +717,7 @@ class TestController:
             dataStorage.addVoltage(v)
             dataStorage.addCurrent(c)
             dataStorage.addCapacity(capacity)
-            if v <= 2.75:
+            if v <= min_voltage:
                 break
 
         self.stopDischarge()

--- a/MAIN.py
+++ b/MAIN.py
@@ -117,6 +117,7 @@ def main():
     parser = argparse.ArgumentParser(description="Run UPS test")
     parser.add_argument("--config-file", help="JSON file with cell settings")
     parser.add_argument("--profile", help="cell profile name in config file")
+    parser.add_argument("--capacity-config", help="JSON defaults for capacity test")
     parser.add_argument("--test-name")
     parser.add_argument("--temperature", type=float)
     parser.add_argument("--charge-volt-prot", type=int)
@@ -178,6 +179,14 @@ def main():
     if args.config_file:
         config = load_config(args.config_file, profile)
 
+    capacity_defaults = {}
+    if args.capacity_config:
+        try:
+            capacity_defaults = json.loads(Path(args.capacity_config).read_text())
+        except Exception as exc:
+            print(f"Failed to load capacity config: {exc}")
+            capacity_defaults = {}
+
     for field in UPSSettings.__annotations__.keys():
         if getattr(args, field) is None:
             if field in config:
@@ -195,11 +204,20 @@ def main():
 
     if args.actual_capacity_test:
         tc = TestController(args.multimeter_mode)
+        rest_time = capacity_defaults.get("rest_time", 3600.0)
+        cap_charge_volt = charge_volt_end
+        if args.charge_volt_end is None and "charge_voltage" in capacity_defaults:
+            cap_charge_volt = capacity_defaults["charge_voltage"]
+        cap_min_volt = dcharge_volt_min
+        if args.dcharge_volt_min is None and "min_voltage" in capacity_defaults:
+            cap_min_volt = capacity_defaults["min_voltage"]
+
         tc.actual_capacity_test(
             args.capacity_charge_current,
             args.capacity_discharge_current,
-            3600.0,
-            charge_volt_end,
+            rest_time,
+            cap_charge_volt,
+            cap_min_volt,
             temperature,
         )
     elif args.efficiency_test:
@@ -236,11 +254,20 @@ def main():
             args.pulse_duration,
             temperature,
         )
+        rest_time = capacity_defaults.get("rest_time", 3600.0)
+        cap_charge_volt = charge_volt_end
+        if args.charge_volt_end is None and "charge_voltage" in capacity_defaults:
+            cap_charge_volt = capacity_defaults["charge_voltage"]
+        cap_min_volt = dcharge_volt_min
+        if args.dcharge_volt_min is None and "min_voltage" in capacity_defaults:
+            cap_min_volt = capacity_defaults["min_voltage"]
+
         capacity = tc.actual_capacity_test(
             args.capacity_charge_current,
             args.capacity_discharge_current,
-            3600.0,
-            charge_volt_end,
+            rest_time,
+            cap_charge_volt,
+            cap_min_volt,
             temperature,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ python MAIN.py --actual-capacity-test \
 
 ``--charge-volt-end`` defaults to **4.1&nbsp;V** if not specified.
 
+You can also supply defaults for the capacity test via a JSON file:
+
+```bash
+python MAIN.py --actual-capacity-test --capacity-config tests/capacity_defaults.json
+```
+
+The file may define ``rest_time``, ``charge_voltage`` and ``min_voltage`` keys.
+Any command-line options take precedence over the values loaded from the file.
+
 Additional tests can be invoked with the following flags:
 
 - **Efficiency test**

--- a/tests/capacity_defaults.json
+++ b/tests/capacity_defaults.json
@@ -1,0 +1,5 @@
+{
+  "rest_time": 3600,
+  "charge_voltage": 4.1,
+  "min_voltage": 2.75
+}


### PR DESCRIPTION
## Summary
- add `tests/capacity_defaults.json` example file
- allow MAIN.py to load a capacity defaults file
- extend `actual_capacity_test` to accept min voltage
- document capacity defaults option in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6889f8cccdf08325b95045d9a0a8666b