### PR TITLE
Add configurable capacity test parameters

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -657,13 +657,14 @@ class TestController:
         discharge_current_1c: float,
         rest_time: float = 3600.0,
         charge_voltage: float = 4.1,
+        min_voltage: float = 2.75,
         temperature: float = 20.0,
     ) -> float:
         """Perform an actual capacity test.
 
         The procedure charges the cell at ``charge_current_1c`` up to ``charge_voltage``,
-        rests for one hour and then discharges at ``discharge_current_1c`` down
-        to 2.75 V while logging the cumulative capacity.
+        rests for ``rest_time`` seconds and then discharges at ``discharge_current_1c``
+        down to ``min_voltage`` while logging the cumulative capacity.
         """
 
         dataStorage = DataStorage()
@@ -705,7 +706,7 @@ class TestController:
         self.setCCcurrentL1(discharge_current_1c)
         self.startDischarge()
 
-        print(f"Discharging to 2.75 V at {discharge_current_1c} A")
+        print(f"Discharging to {min_voltage} V at {discharge_current_1c} A")
         while True:
             time.sleep(self.timeInterval)
             elapsed += self.timeInterval
@@ -716,7 +717,7 @@ class TestController:
             dataStorage.addVoltage(v)
             dataStorage.addCurrent(c)
             dataStorage.addCapacity(capacity)
-            if v <= 2.75:
+            if v <= min_voltage:
                 break
 
         self.stopDischarge()

--- a/MAIN.py
+++ b/MAIN.py
@@ -139,6 +139,12 @@ def main():
                         help="charge current for capacity test in amperes")
     parser.add_argument("--capacity-discharge-current", type=float, default=1.0,
                         help="discharge current for capacity test in amperes")
+    parser.add_argument("--capacity-rest-time", type=float, default=3600.0,
+                        help="rest time before discharge in seconds")
+    parser.add_argument("--capacity-charge-voltage", type=float,
+                        help="charge voltage for capacity test")
+    parser.add_argument("--capacity-min-voltage", type=float,
+                        help="minimum discharge voltage for capacity test")
     parser.add_argument("--efficiency-test", action="store_true",
                         help="run efficiency test")
     parser.add_argument("--rate-characteristic-test", action="store_true",
@@ -193,13 +199,18 @@ def main():
     dcharge_current_max = args.dcharge_current_max if args.dcharge_current_max is not None else DCHARGE_CURRENT_MAX
     temperature = args.temperature if args.temperature is not None else TEMPERATURE
 
+    capacity_rest_time = args.capacity_rest_time
+    capacity_charge_voltage = args.capacity_charge_voltage if args.capacity_charge_voltage is not None else charge_volt_end
+    capacity_min_voltage = args.capacity_min_voltage if args.capacity_min_voltage is not None else dcharge_volt_min
+
     if args.actual_capacity_test:
         tc = TestController(args.multimeter_mode)
         tc.actual_capacity_test(
             args.capacity_charge_current,
             args.capacity_discharge_current,
-            3600.0,
-            charge_volt_end,
+            capacity_rest_time,
+            capacity_charge_voltage,
+            capacity_min_voltage,
             temperature,
         )
     elif args.efficiency_test:
@@ -239,8 +250,9 @@ def main():
         capacity = tc.actual_capacity_test(
             args.capacity_charge_current,
             args.capacity_discharge_current,
-            3600.0,
-            charge_volt_end,
+            capacity_rest_time,
+            capacity_charge_voltage,
+            capacity_min_voltage,
             temperature,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")

--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ To perform a full capacity measurement instead of the default cycling test run:
 python MAIN.py --actual-capacity-test \
   --capacity-charge-current 1.0 \
   --capacity-discharge-current 1.0 \
-  [--charge-volt-end 4.1]
+  [--capacity-rest-time 3600] \
+  [--capacity-charge-voltage 4.1] \
+  [--capacity-min-voltage 2.75]
 ```
-
-``--charge-volt-end`` defaults to **4.1&nbsp;V** if not specified.
+``--capacity-charge-voltage`` defaults to the value of ``--charge-volt-end`` (or
+``4.1``&nbsp;V), ``--capacity-rest-time`` defaults to one hour and
+``--capacity-min-voltage`` defaults to ``2.75``&nbsp;V if not specified.
 
 Additional tests can be invoked with the following flags:
 
@@ -97,9 +100,11 @@ python MAIN.py --config-file cell_profiles.json --profile YUASA
 Command-line options still override the values loaded from the profile.
 
 This charges the cell at 1C up to the voltage specified by
-`--charge-volt-end` (default **4.1&nbsp;V**), rests for a configurable
-period (default one hour) at 20&nbsp;±&nbsp;2 °C and then discharges at 1C
-down to **2.75&nbsp;V** while recording the delivered ampere hours.
+`--capacity-charge-voltage` (default taken from `--charge-volt-end`),
+rests for the duration given by `--capacity-rest-time` (default one hour)
+at 20&nbsp;±&nbsp;2 °C and then discharges at 1C down to
+`--capacity-min-voltage` (default **2.75&nbsp;V**) while recording the
+delivered ampere hours.
 
 By default the parameters in `MAIN.py` define a single cycle with
 16.21&ndash;16.4&nbsp;V charging at 5&nbsp;A and a discharge down to 11&nbsp;V.


### PR DESCRIPTION
## Summary
- allow overriding rest time and voltages when running capacity tests
- pass new arguments to `actual_capacity_test`
- document the new options in the README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6889f8c89e8c83258dc957935727c879