### PR TITLE
Add optional debug prints

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -19,8 +19,9 @@ class TestController:
     # Variable for keeping track of the C-rate of the battery
 
     # Initiating function
-    def __init__(self, multimeter_mode: str | None = None) -> None:
+    def __init__(self, multimeter_mode: str | None = None, debug: bool = False) -> None:
         self.multimeter_mode = multimeter_mode
+        self.debug = debug
         try:
             # Trying to connect to the real device controllers
             self.powerSupplyController = PowerSupplyController()
@@ -56,6 +57,11 @@ class TestController:
         self.event = threading.Event()
         # Event used to gracefully abort a running test
         self.stop_event = threading.Event()
+
+    def _debug(self, message: str) -> None:
+        """Print debug message when debug mode is enabled."""
+        if self.debug:
+            print(message)
 
     def abort(self) -> None:
         """Stop all outputs and signal running loops to exit."""
@@ -344,7 +350,9 @@ class TestController:
                         v_ps = self.getVoltagePSC()
                         v = self.getVoltageELC()
                         c = self.getCurrentPSC()
-                        print(f"{cycleNumber} of {num_cycles} -CHARGING- {tmp.total_seconds():03.2f} s of {Cduration.total_seconds():.1f} s - V_PS:{v_ps:.4f} V:{v:.4f} C:{c:.4f}")
+                        self._debug(
+                            f"{cycleNumber} of {num_cycles} -CHARGING- {tmp.total_seconds():03.2f} s of {Cduration.total_seconds():.1f} s - V_PS:{v_ps:.4f} V:{v:.4f} C:{c:.4f}"
+                        )
                         dataStorage.addTime(float(tmp.total_seconds()))
                         dataStorage.addVoltage(v)
                         dataStorage.addCurrent(c)
@@ -367,7 +375,9 @@ class TestController:
                         tmp = datetime.now()-DischargestartTime
                         v = self.getVoltageELC()
                         c = self.getCurrentELC()
-                        print(f"{cycleNumber} of {num_cycles} -DISCHARGING- {tmp.total_seconds():03.2f} s of {Dduration.total_seconds():.1f} s - V:{v:.4f} C:{c:.4f}")
+                        self._debug(
+                            f"{cycleNumber} of {num_cycles} -DISCHARGING- {tmp.total_seconds():03.2f} s of {Dduration.total_seconds():.1f} s - V:{v:.4f} C:{c:.4f}"
+                        )
                         dataStorage.addTime(float(tmp.total_seconds()))
                         dataStorage.addVoltage(v)
                         dataStorage.addCurrent(c)
@@ -437,6 +447,9 @@ class TestController:
             elapsed += self.timeInterval
             v = self.getVoltagePSC()
             c = self.getCurrentPSC()
+            self._debug(
+                f"CC Charging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f}"
+            )
             energy_in += v * c * self.timeInterval / 3600.0
             dataStorage.addTime(elapsed)
             dataStorage.addVoltage(v)
@@ -452,6 +465,9 @@ class TestController:
             elapsed += self.timeInterval
             v = self.getVoltagePSC()
             c = self.getCurrentPSC()
+            self._debug(
+                f"CV Charging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f}"
+            )
             energy_in += v * c * self.timeInterval / 3600.0
             dataStorage.addTime(elapsed)
             dataStorage.addVoltage(v)
@@ -475,6 +491,9 @@ class TestController:
             elapsed += self.timeInterval
             v = self.getVoltageELC()
             c = self.getCurrentELC()
+            self._debug(
+                f"Discharging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f}"
+            )
             energy_out += v * c * self.timeInterval / 3600.0
             dataStorage.addTime(elapsed)
             dataStorage.addVoltage(v)
@@ -521,6 +540,9 @@ class TestController:
                 elapsed += self.timeInterval
                 v = self.getVoltagePSC()
                 c = self.getCurrentPSC()
+                self._debug(
+                    f"CC Charging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f}"
+                )
                 dataStorage.addTime(elapsed)
                 dataStorage.addVoltage(v)
                 dataStorage.addCurrent(c)
@@ -532,6 +554,9 @@ class TestController:
                 elapsed += self.timeInterval
                 v = self.getVoltagePSC()
                 c = self.getCurrentPSC()
+                self._debug(
+                    f"CV Charging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f}"
+                )
                 dataStorage.addTime(elapsed)
                 dataStorage.addVoltage(v)
                 dataStorage.addCurrent(c)
@@ -553,6 +578,9 @@ class TestController:
                 v = self.getVoltageELC()
                 c = self.getCurrentELC()
                 capacity += c * self.timeInterval / 3600.0
+                self._debug(
+                    f"Discharging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f} Ah:{capacity:.3f}"
+                )
                 dataStorage.addTime(elapsed)
                 dataStorage.addVoltage(v)
                 dataStorage.addCurrent(c)
@@ -684,6 +712,9 @@ class TestController:
             elapsed += self.timeInterval
             v = self.getVoltageELC()
             c = self.getCurrentPSC()
+            self._debug(
+                f"Charging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f} Ah:{capacity:.3f}"
+            )
             dataStorage.addTime(elapsed)
             dataStorage.addVoltage(v)
             dataStorage.addCurrent(c)
@@ -710,6 +741,9 @@ class TestController:
             v = self.getVoltageELC()
             c = self.getCurrentELC()
             capacity += c * self.timeInterval / 3600.0
+            self._debug(
+                f"Discharging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f} Ah:{capacity:.3f}"
+            )
             dataStorage.addTime(elapsed)
             dataStorage.addVoltage(v)
             dataStorage.addCurrent(c)

--- a/MAIN.py
+++ b/MAIN.py
@@ -72,8 +72,8 @@ def load_config(config_path: str, profile: str) -> dict:
 
 
 class TestTypes:
-    def __init__(self, multimeter_mode: str | None = None):
-        self.testController = TestController(multimeter_mode)
+    def __init__(self, multimeter_mode: str | None = None, debug: bool = False):
+        self.testController = TestController(multimeter_mode, debug)
         self.upsThread = None
 
     def runUPSTest(self, settings: UPSSettings):
@@ -174,6 +174,12 @@ def main():
         action="store_true",
         help="DEPRECATED: same as --multimeter-mode voltage"
     )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="print detailed progress information",
+    )
 
     args = parser.parse_args()
 
@@ -227,7 +233,7 @@ def main():
             cap_min_volt = dcharge_volt_min
 
     if args.actual_capacity_test:
-        tc = TestController(args.multimeter_mode)
+        tc = TestController(args.multimeter_mode, args.debug)
         tc.actual_capacity_test(
             args.capacity_charge_current,
             args.capacity_discharge_current,
@@ -237,7 +243,7 @@ def main():
             temperature,
         )
     elif args.efficiency_test:
-        tc = TestController(args.multimeter_mode)
+        tc = TestController(args.multimeter_mode, args.debug)
         tc.efficiency_test(
             charge_current_max,
             dcharge_current_max,
@@ -247,7 +253,7 @@ def main():
         )
     elif args.rate_characteristic_test:
         rates = [float(r) for r in args.rates.split(',') if r]
-        tc = TestController(args.multimeter_mode)
+        tc = TestController(args.multimeter_mode, args.debug)
         tc.rate_characteristic_test(
             rates,
             charge_current_max,
@@ -256,7 +262,7 @@ def main():
             temperature,
         )
     elif args.ocv_curve_test:
-        tc = TestController(args.multimeter_mode)
+        tc = TestController(args.multimeter_mode, args.debug)
         tc.ocv_curve_test(
             args.step_current,
             args.steps,
@@ -264,7 +270,7 @@ def main():
             temperature,
         )
     elif args.internal_resistance_test:
-        tc = TestController(args.multimeter_mode)
+        tc = TestController(args.multimeter_mode, args.debug)
         tc.internal_resistance_test(
             args.pulse_current,
             args.pulse_duration,
@@ -288,7 +294,7 @@ def main():
                 kwargs[field] = val
         settings = UPSSettings(**kwargs)
 
-        TObj = TestTypes(args.multimeter_mode)
+        TObj = TestTypes(args.multimeter_mode, args.debug)
         thread = TObj.runUPSTest(settings)
         try:
             while thread.is_alive():

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ python MAIN.py
 ```
    If no hardware connection is detected the program will ask whether to
    continue using mock drivers.
+   Use the `-d` flag to print detailed progress messages during a test.
 
 To perform a full capacity measurement instead of the default cycling test run:
 
@@ -173,6 +174,7 @@ common flags accepted by `MAIN.py` are listed below. Run
 | `--dcharge-time` | Allowed discharging time |
 | `--num-cycles` | Number of charge/discharge cycles |
 | `--multimeter-mode` | Log measurement using the multimeter (`voltage` or `tcouple`) |
+| `-d`, `--debug` | Print detailed progress information |
 
 
 ## Manufacturer Programming Manuals


### PR DESCRIPTION
## Summary
- add debug flag to CLI
- print extra progress info when debug enabled
- document debug flag

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688a071771b88325ae6ed2392dbe880c