### PR TITLE
Update capacity config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ You can also supply defaults for the capacity test via a JSON file:
 python MAIN.py --actual-capacity-test --capacity-config tests/capacity_defaults.json
 ```
 
-The file may define ``rest_time``, ``charge_voltage`` and ``min_voltage`` keys.
+The file may define ``rest_time``, ``charge_voltage``, ``min_voltage``,
+``charge_current``, ``discharge_current`` and ``multimeter_mode`` keys.
 These values override the built‑in defaults in ``MAIN.py`` but any
 command-line options still take precedence.
 

--- a/tests/capacity_defaults.json
+++ b/tests/capacity_defaults.json
@@ -1,5 +1,8 @@
 {
   "rest_time": 60,
   "charge_voltage": 4.1,
-  "min_voltage": 2.75
+  "min_voltage": 2.75,
+  "charge_current": 1.0,
+  "discharge_current": 1.0,
+  "multimeter_mode": "voltage"
 }


### PR DESCRIPTION
## Summary
- support charge/discharge current and multimeter mode defaults
- mention new keys in README
- update example capacity configuration file

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688a080244908325a33f05d409947011