### PR TITLE
Fix capacity test syntax and defaults

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -708,23 +708,23 @@ class TestController:
                 self.chargeCC(charge_current_1c)
                 self.setVoltage(charge_voltage)
 
-        elapsed = 0.0
-        capacity = 0.0
-        print(f"Charging to {charge_voltage} V at {charge_current_1c} A")
-        while True:
-            time.sleep(self.timeInterval)
-            elapsed += self.timeInterval
-            v = self.getVoltageELC()
-            c = self.getCurrentPSC()
-            self._debug(
-                f"Charging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f} Ah:{capacity:.3f}"
-            )
-            dataStorage.addTime(elapsed)
-            dataStorage.addVoltage(v)
-            dataStorage.addCurrent(c)
-            dataStorage.addCapacity(capacity)
-            if c <= 1.5:
-                break
+                elapsed = 0.0
+                capacity = 0.0
+                print(f"Charging to {charge_voltage} V at {charge_current_1c} A")
+                while True:
+                    time.sleep(self.timeInterval)
+                    elapsed += self.timeInterval
+                    v = self.getVoltageELC()
+                    c = self.getCurrentPSC()
+                    self._debug(
+                        f"Charging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f} Ah:{capacity:.3f}"
+                    )
+                    dataStorage.addTime(elapsed)
+                    dataStorage.addVoltage(v)
+                    dataStorage.addCurrent(c)
+                    dataStorage.addCapacity(capacity)
+                    if c <= 1.5:
+                        break
 
                 self.stopPSOutput()
 
@@ -738,22 +738,22 @@ class TestController:
                 self.setCCcurrentL1(discharge_current_1c)
                 self.startDischarge()
 
-        print(f"Discharging to {min_voltage} V at {discharge_current_1c} A")
-        while True:
-            time.sleep(self.timeInterval)
-            elapsed += self.timeInterval
-            v = self.getVoltageELC()
-            c = self.getCurrentELC()
-            capacity += c * self.timeInterval / 3600.0
-            self._debug(
-                f"Discharging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f} Ah:{capacity:.3f}"
-            )
-            dataStorage.addTime(elapsed)
-            dataStorage.addVoltage(v)
-            dataStorage.addCurrent(c)
-            dataStorage.addCapacity(capacity)
-            if v <= min_voltage:
-                break
+                print(f"Discharging to {min_voltage} V at {discharge_current_1c} A")
+                while True:
+                    time.sleep(self.timeInterval)
+                    elapsed += self.timeInterval
+                    v = self.getVoltageELC()
+                    c = self.getCurrentELC()
+                    capacity += c * self.timeInterval / 3600.0
+                    self._debug(
+                        f"Discharging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f} Ah:{capacity:.3f}"
+                    )
+                    dataStorage.addTime(elapsed)
+                    dataStorage.addVoltage(v)
+                    dataStorage.addCurrent(c)
+                    dataStorage.addCapacity(capacity)
+                    if v <= min_voltage:
+                        break
 
                 self.stopDischarge()
             except KeyboardInterrupt:

--- a/MAIN.py
+++ b/MAIN.py
@@ -247,7 +247,7 @@ def main():
             cap_min_volt = dcharge_volt_min
 
     if args.actual_capacity_test:
-        tc = TestController(args.multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug)
         tc.actual_capacity_test(
             cap_charge_current,
             cap_discharge_current,
@@ -257,7 +257,7 @@ def main():
             temperature,
         )
     elif args.efficiency_test:
-        tc = TestController(args.multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug)
         tc.efficiency_test(
             charge_current_max,
             dcharge_current_max,
@@ -267,7 +267,7 @@ def main():
         )
     elif args.rate_characteristic_test:
         rates = [float(r) for r in args.rates.split(',') if r]
-        tc = TestController(args.multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug)
         tc.rate_characteristic_test(
             rates,
             charge_current_max,
@@ -276,7 +276,7 @@ def main():
             temperature,
         )
     elif args.ocv_curve_test:
-        tc = TestController(args.multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug)
         tc.ocv_curve_test(
             args.step_current,
             args.steps,
@@ -284,7 +284,7 @@ def main():
             temperature,
         )
     elif args.internal_resistance_test:
-        tc = TestController(args.multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug)
         tc.internal_resistance_test(
             args.pulse_current,
             args.pulse_duration,
@@ -308,7 +308,7 @@ def main():
                 kwargs[field] = val
         settings = UPSSettings(**kwargs)
 
-        TObj = TestTypes(args.multimeter_mode, args.debug)
+        TObj = TestTypes(multimeter_mode, args.debug)
         thread = TObj.runUPSTest(settings)
         try:
             while thread.is_alive():


### PR DESCRIPTION
## Summary
- fix indentation in `actual_capacity_test`
- use multimeter defaults from config when instantiating `TestController`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688a0c0598008325923b4fa1ec108312