### PR TITLE
Fix missing multimeter data in capacity test

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -722,6 +722,10 @@ class TestController:
                     dataStorage.addTime(elapsed)
                     dataStorage.addVoltage(v)
                     dataStorage.addCurrent(c)
+                    if self.multimeter_mode == "voltage":
+                        dataStorage.addMMVoltage(self.getVoltageMM())
+                    elif self.multimeter_mode == "tcouple":
+                        dataStorage.addMMTemperature(self.getTemperatureMM())
                     dataStorage.addCapacity(capacity)
                     if c <= 1.5:
                         break
@@ -751,6 +755,10 @@ class TestController:
                     dataStorage.addTime(elapsed)
                     dataStorage.addVoltage(v)
                     dataStorage.addCurrent(c)
+                    if self.multimeter_mode == "voltage":
+                        dataStorage.addMMVoltage(self.getVoltageMM())
+                    elif self.multimeter_mode == "tcouple":
+                        dataStorage.addMMTemperature(self.getTemperatureMM())
                     dataStorage.addCapacity(capacity)
                     if v <= min_voltage:
                         break


### PR DESCRIPTION
## Summary
- log multimeter readings when running `actual_capacity_test` so the CSV includes temperature or voltage data

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688a0dd2ae8c8325ba87a16be42a4aa9