### PR TITLE
Add configurable finish current for capacity test

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -684,12 +684,14 @@ class TestController:
         charge_voltage: float = 4.1,
         min_voltage: float = 2.75,
         temperature: float = 20.0,
+        finish_current: float = 1.5,
     ) -> float:
         """Perform an actual capacity test.
 
         The procedure charges the cell at ``charge_current_1c`` up to ``charge_voltage``,
         rests for ``rest_time`` seconds and then discharges at ``discharge_current_1c``
-        down to ``min_voltage`` while logging the cumulative capacity.
+        down to ``min_voltage`` while logging the cumulative capacity. The
+        charging phase ends once the supply current drops below ``finish_current``.
         """
 
         dataStorage = DataStorage()
@@ -727,7 +729,7 @@ class TestController:
                     elif self.multimeter_mode == "tcouple":
                         dataStorage.addMMTemperature(self.getTemperatureMM())
                     dataStorage.addCapacity(capacity)
-                    if c <= 1.5:
+                    if c <= finish_current:
                         break
 
                 self.stopPSOutput()

--- a/MAIN.py
+++ b/MAIN.py
@@ -146,6 +146,8 @@ def main():
                         help="charge voltage for capacity test")
     parser.add_argument("--capacity-min-voltage", type=float,
                         help="minimum discharge voltage for capacity test")
+    parser.add_argument("--capacity-finish-current", type=float,
+                        help="current threshold to end charging during capacity test")
     parser.add_argument("--efficiency-test", action="store_true",
                         help="run efficiency test")
     parser.add_argument("--rate-characteristic-test", action="store_true",
@@ -246,6 +248,10 @@ def main():
         else:
             cap_min_volt = dcharge_volt_min
 
+    finish_current = args.capacity_finish_current
+    if finish_current is None:
+        finish_current = capacity_defaults.get("finish_current", 1.5)
+
     if args.actual_capacity_test:
         tc = TestController(multimeter_mode, args.debug)
         tc.actual_capacity_test(
@@ -255,6 +261,7 @@ def main():
             cap_charge_volt,
             cap_min_volt,
             temperature,
+            finish_current,
         )
     elif args.efficiency_test:
         tc = TestController(multimeter_mode, args.debug)
@@ -297,6 +304,7 @@ def main():
             cap_charge_volt,
             cap_min_volt,
             temperature,
+            finish_current,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ python MAIN.py --actual-capacity-test \
   --capacity-discharge-current 1.0 \
   [--capacity-rest-time 3600] \
   [--capacity-charge-voltage 4.1] \
-  [--capacity-min-voltage 2.75]
+  [--capacity-min-voltage 2.75] \
+  [--capacity-finish-current 1.5]
 ```
 ``--capacity-charge-voltage`` defaults to the value of ``--charge-volt-end``
 (or ``4.1``&nbsp;V). ``--capacity-rest-time`` and ``--capacity-min-voltage``
@@ -58,7 +59,8 @@ python MAIN.py --actual-capacity-test --capacity-config tests/capacity_defaults.
 ```
 
 The file may define ``rest_time``, ``charge_voltage``, ``min_voltage``,
-``charge_current``, ``discharge_current`` and ``multimeter_mode`` keys.
+``charge_current``, ``discharge_current``, ``finish_current`` and
+``multimeter_mode`` keys.
 These values override the built‑in defaults in ``MAIN.py`` but any
 command-line options still take precedence.
 

--- a/tests/capacity_defaults.json
+++ b/tests/capacity_defaults.json
@@ -3,6 +3,7 @@
   "charge_voltage": 4.1,
   "min_voltage": 2.75,
   "charge_current": 46.0,
+  "finish_current": 1.5,
   "discharge_current": 46.0,
   "multimeter_mode": "tcouple"
 }


### PR DESCRIPTION
## Summary
- allow configuring the current used to stop charging in `actual_capacity_test`
- expose new `--capacity-finish-current` CLI argument
- document the option and update example defaults
- include `finish_current` in the sample `capacity_defaults.json`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688a122f8cb883259c33d5f69814b0a9