### PR TITLE
Update finish current condition

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -713,7 +713,8 @@ class TestController:
         The procedure charges the cell at ``charge_current_1c`` up to ``charge_voltage``,
         rests for ``rest_time`` seconds and then discharges at ``discharge_current_1c``
         down to ``min_voltage`` while logging the cumulative capacity. The
-        charging phase ends once the supply current drops below ``finish_current``.
+        charging phase ends once the supply current stays below ``finish_current``
+        for at least 10 seconds.
         """
 
         dataStorage = DataStorage()
@@ -735,6 +736,7 @@ class TestController:
                 elapsed = 0.0
                 capacity = 0.0
                 print(f"Charging to {charge_voltage} V at {charge_current_1c} A")
+                low_current_time = 0.0
                 while True:
                     time.sleep(self.timeInterval)
                     elapsed += self.timeInterval
@@ -760,7 +762,11 @@ class TestController:
                         dataStorage.addMMTemperature(mm)
                     dataStorage.addCapacity(capacity)
                     if c <= finish_current:
-                        break
+                        low_current_time += self.timeInterval
+                        if low_current_time >= 10.0:
+                            break
+                    else:
+                        low_current_time = 0.0
 
                 self.stopPSOutput()
 


### PR DESCRIPTION
## Summary
- allow the charge stage in `actual_capacity_test` to finish only
  after the supply current is below the `finish_current` limit for
  at least 10 seconds
- document this new condition in the function docstring

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688a3341a30483258a76c824af7e3b1a