### PR TITLE
Use PS voltage during discharge

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -784,7 +784,9 @@ class TestController:
                 while True:
                     time.sleep(self.timeInterval)
                     elapsed += self.timeInterval
-                    v = self.getVoltageELC()
+                    # Temporary workaround: use the power supply voltage once
+                    # discharging starts until Vsense wiring is available
+                    v = self.getVoltagePSC()
                     c = self.getCurrentELC()
                     capacity += c * self.timeInterval / 3600.0
                     mm = None

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ The file may define ``rest_time``, ``charge_voltage``, ``min_voltage``,
 These values override the built‑in defaults in ``MAIN.py`` but any
 command-line options still take precedence.
 
+Note: during the discharge stage of ``actual_capacity_test`` the
+voltage is temporarily read from the power supply. Once sensing cables
+are connected to the electronic load's Vsense terminal this workaround
+will be removed.
+
 Additional tests can be invoked with the following flags:
 
 - **Efficiency test**


### PR DESCRIPTION
## Summary
- workaround: read voltage from power supply during discharge
- document the temporary fix

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688a36d3f52c8325ae3d29fa4e0fe1c3