### PR TITLE
Add skip flag for capacity test

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -707,14 +707,15 @@ class TestController:
         min_voltage: float = 2.75,
         temperature: float = 20.0,
         finish_current: float = 1.5,
+        skip_charge: bool = False,
     ) -> float:
         """Perform an actual capacity test.
 
-        The procedure charges the cell at ``charge_current_1c`` up to ``charge_voltage``,
-        rests for ``rest_time`` seconds and then discharges at ``discharge_current_1c``
-        down to ``min_voltage`` while logging the cumulative capacity. The
-        charging phase ends once the supply current stays below ``finish_current``
-        for at least 10 seconds.
+        The procedure charges the cell at ``charge_current_1c`` up to ``charge_voltage``
+        (unless ``skip_charge`` is ``True``), rests for ``rest_time`` seconds and then
+        discharges at ``discharge_current_1c`` down to ``min_voltage`` while logging the
+        cumulative capacity. The charging phase ends once the supply current stays below
+        ``finish_current`` for at least 10 seconds.
         """
 
         dataStorage = DataStorage()
@@ -724,51 +725,54 @@ class TestController:
         capacity = 0.0
         try:
             try:
-                # ----- Charge step -----
-                self.apply_safety_limits(
-                    charge_volt_end=charge_voltage,
-                    charge_current_max=charge_current_1c,
-                )
-                self.startPSOutput()
-                self.chargeCC(charge_current_1c)
-                self.setVoltage(charge_voltage)
-
-                elapsed = 0.0
-                capacity = 0.0
-                print(f"Charging to {charge_voltage} V at {charge_current_1c} A")
-                low_current_time = 0.0
-                while True:
-                    time.sleep(self.timeInterval)
-                    elapsed += self.timeInterval
-                    v = self.getVoltageELC()
-                    c = self.getCurrentPSC()
-                    mm = None
-                    if self.multimeter_mode == "voltage":
-                        mm = self.getVoltageMM()
-                    elif self.multimeter_mode == "tcouple":
-                        mm = self.getTemperatureMM()
-                    self._debug(
-                        f"Charging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f} Ah:{capacity:.3f}",
-                        mm,
+                if not skip_charge:
+                    # ----- Charge step -----
+                    self.apply_safety_limits(
+                        charge_volt_end=charge_voltage,
+                        charge_current_max=charge_current_1c,
                     )
-                    dataStorage.addTime(elapsed)
-                    dataStorage.addVoltage(v)
-                    dataStorage.addCurrent(c)
-                    if self.multimeter_mode == "voltage":
-                        assert mm is not None
-                        dataStorage.addMMVoltage(mm)
-                    elif self.multimeter_mode == "tcouple":
-                        assert mm is not None
-                        dataStorage.addMMTemperature(mm)
-                    dataStorage.addCapacity(capacity)
-                    if c <= finish_current:
-                        low_current_time += self.timeInterval
-                        if low_current_time >= 10.0:
-                            break
-                    else:
-                        low_current_time = 0.0
+                    self.startPSOutput()
+                    self.chargeCC(charge_current_1c)
+                    self.setVoltage(charge_voltage)
 
-                self.stopPSOutput()
+                    elapsed = 0.0
+                    capacity = 0.0
+                    print(
+                        f"Charging to {charge_voltage} V at {charge_current_1c} A"
+                    )
+                    low_current_time = 0.0
+                    while True:
+                        time.sleep(self.timeInterval)
+                        elapsed += self.timeInterval
+                        v = self.getVoltageELC()
+                        c = self.getCurrentPSC()
+                        mm = None
+                        if self.multimeter_mode == "voltage":
+                            mm = self.getVoltageMM()
+                        elif self.multimeter_mode == "tcouple":
+                            mm = self.getTemperatureMM()
+                        self._debug(
+                            f"Charging: {elapsed:.2f} s - V:{v:.4f} C:{c:.4f} Ah:{capacity:.3f}",
+                            mm,
+                        )
+                        dataStorage.addTime(elapsed)
+                        dataStorage.addVoltage(v)
+                        dataStorage.addCurrent(c)
+                        if self.multimeter_mode == "voltage":
+                            assert mm is not None
+                            dataStorage.addMMVoltage(mm)
+                        elif self.multimeter_mode == "tcouple":
+                            assert mm is not None
+                            dataStorage.addMMTemperature(mm)
+                        dataStorage.addCapacity(capacity)
+                        if c <= finish_current:
+                            low_current_time += self.timeInterval
+                            if low_current_time >= 10.0:
+                                break
+                        else:
+                            low_current_time = 0.0
+
+                    self.stopPSOutput()
 
                 # ----- Rest step -----
                 print(f"Resting for {rest_time} seconds")

--- a/MAIN.py
+++ b/MAIN.py
@@ -148,6 +148,13 @@ def main():
                         help="minimum discharge voltage for capacity test")
     parser.add_argument("--capacity-finish-current", type=float,
                         help="current threshold to end charging during capacity test")
+    parser.add_argument(
+        "-skip",
+        "--skip",
+        dest="skip_charge",
+        action="store_true",
+        help="skip the charging phase of actual capacity test",
+    )
     parser.add_argument("--efficiency-test", action="store_true",
                         help="run efficiency test")
     parser.add_argument("--rate-characteristic-test", action="store_true",
@@ -262,6 +269,7 @@ def main():
             cap_min_volt,
             temperature,
             finish_current,
+            skip_charge=args.skip_charge,
         )
     elif args.efficiency_test:
         tc = TestController(multimeter_mode, args.debug)
@@ -305,6 +313,7 @@ def main():
             cap_min_volt,
             temperature,
             finish_current,
+            skip_charge=args.skip_charge,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ python MAIN.py --actual-capacity-test \
 (or ``4.1``&nbsp;V). ``--capacity-rest-time`` and ``--capacity-min-voltage``
 fall back to the values in the file passed with ``--capacity-config`` or,
 if that option is omitted, to one hour and ``2.75``&nbsp;V respectively.
+Use the ``-skip`` flag to resume discharging without a charge step when
+continuing an interrupted capacity test.
 
 You can also supply defaults for the capacity test via a JSON file:
 


### PR DESCRIPTION
## Summary
- allow skipping charging step in `actual_capacity_test`
- expose `-skip/--skip` command line option
- mention the new option in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688a3e2b442c8325815ca665e4adbc76