### PR TITLE
Add skip flag for capacity test

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -148,6 +148,13 @@ def main():
                         help="minimum discharge voltage for capacity test")
     parser.add_argument("--capacity-finish-current", type=float,
                         help="current threshold to end charging during capacity test")
+    parser.add_argument(
+        "-skip",
+        "--skip",
+        dest="skip_charge",
+        action="store_true",
+        help="skip the charging phase of actual capacity test",
+    )
     parser.add_argument("--efficiency-test", action="store_true",
                         help="run efficiency test")
     parser.add_argument("--rate-characteristic-test", action="store_true",
@@ -262,6 +269,7 @@ def main():
             cap_min_volt,
             temperature,
             finish_current,
+            skip_charge=args.skip_charge,
         )
     elif args.efficiency_test:
         tc = TestController(multimeter_mode, args.debug)
@@ -305,6 +313,7 @@ def main():
             cap_min_volt,
             temperature,
             finish_current,
+            skip_charge=args.skip_charge,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ python MAIN.py --actual-capacity-test \
 (or ``4.1``&nbsp;V). ``--capacity-rest-time`` and ``--capacity-min-voltage``
 fall back to the values in the file passed with ``--capacity-config`` or,
 if that option is omitted, to one hour and ``2.75``&nbsp;V respectively.
+Use the ``-skip`` flag to resume discharging without running the charge or
+rest steps when continuing an interrupted capacity test.
 
 You can also supply defaults for the capacity test via a JSON file:
 


### PR DESCRIPTION
## Summary
- allow skipping charging step in `actual_capacity_test`
- expose `-skip/--skip` command line option
- mention the new option in README
- skip rest time when skip flag is used

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_688a3e2b442c8325815ca665e4adbc76