### PR TITLE
Remove capacity test from internal resistance flag

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -154,18 +154,29 @@ def main():
                         help="run rate characteristic test")
     parser.add_argument("--ocv-curve-test", action="store_true",
                         help="run OCV curve test")
-    parser.add_argument("--internal-resistance-test", action="store_true",
-                        help="run internal resistance test")
+    parser.add_argument(
+        "--internal-resistance-test",
+        action="store_true",
+        help="run internal resistance test (no capacity measurement)",
+    )
     parser.add_argument("--rates", default="1.0,0.5,0.2",
                         help="comma separated discharge rates in A")
     parser.add_argument("--step-current", type=float, default=1.0,
                         help="step current for OCV curve")
     parser.add_argument("--steps", type=int, default=10,
                         help="number of steps for OCV curve")
-    parser.add_argument("--pulse-current", type=float, default=1.0,
-                        help="pulse current for resistance test")
-    parser.add_argument("--pulse-duration", type=float, default=1.0,
-                        help="pulse duration in seconds")
+    parser.add_argument(
+        "--pulse-current",
+        type=float,
+        default=1.0,
+        help="pulse current for internal resistance test",
+    )
+    parser.add_argument(
+        "--pulse-duration",
+        type=float,
+        default=1.0,
+        help="pulse duration for internal resistance test in seconds",
+    )
     parser.add_argument(
         "--multimeter-mode",
         choices=["voltage", "tcouple"],
@@ -297,16 +308,6 @@ def main():
             args.pulse_duration,
             temperature,
         )
-        capacity = tc.actual_capacity_test(
-            cap_charge_current,
-            cap_discharge_current,
-            rest_time,
-            cap_charge_volt,
-            cap_min_volt,
-            temperature,
-            finish_current,
-        )
-        print(f"Measured capacity: {capacity:.3f} Ah")
 
     else:
         kwargs = {}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Additional tests can be invoked with the following flags:
   ```
 
   Applies a short current pulse to determine the DC and AC resistance of the
-  cell.
+  cell. This command only measures resistance; run `--actual-capacity-test`
+  separately to measure capacity.
 
 ### Using configuration files
 


### PR DESCRIPTION
## Summary
- Remove unintended capacity test from `--internal-resistance-test`
- Clarify CLI help text for internal resistance test and pulse parameters
- Document separation of internal resistance and capacity tests in README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689dd2955c608325a2ae7e64f418dc82