### PR TITLE
Implement DC rise/fall SCPI commands with validation

### DIFF
--- a/AlIonTestSoftwareDeviceDrivers.py
+++ b/AlIonTestSoftwareDeviceDrivers.py
@@ -65,11 +65,37 @@ class PowerSupplyController:
     #     self.powerSupply.write("SOUR:POW:PROT:HIGH MAX")  # Could not find MAX command in manual
 
     #### DC RISE/FALL #### DC RISE/FALL #### DC RISE/FALL ####
-    def setDC_Rise(self, *volts):
-        self.powerSupply.write("SOUR:POW:PROT:HIGH " + str(volts[0]))
+    def setDC_Rise(self, rate_v_per_ms: float) -> None:
+        """Set voltage rise rate.
 
-    def setDC_Fall(self, *volts):
-        self.powerSupply.write("SOUR:POW:PROT:HIGH " + str(volts[0]))
+        Args:
+            rate_v_per_ms: Slew rate in volts per millisecond.
+
+        Raises:
+            ValueError: If ``rate_v_per_ms`` is not positive.
+
+        See Chroma 62000P Programming Manual section on
+        ``SOUR:VOLT:RISE`` for parameter limits.
+        """
+        if rate_v_per_ms <= 0:
+            raise ValueError("Rise rate must be positive (V/ms).")
+        self.powerSupply.write(f"SOUR:VOLT:RISE {rate_v_per_ms}")
+
+    def setDC_Fall(self, rate_v_per_ms: float) -> None:
+        """Set voltage fall rate.
+
+        Args:
+            rate_v_per_ms: Slew rate in volts per millisecond.
+
+        Raises:
+            ValueError: If ``rate_v_per_ms`` is not positive.
+
+        See Chroma 62000P Programming Manual section on
+        ``SOUR:VOLT:FALL`` for parameter limits.
+        """
+        if rate_v_per_ms <= 0:
+            raise ValueError("Fall rate must be positive (V/ms).")
+        self.powerSupply.write(f"SOUR:VOLT:FALL {rate_v_per_ms}")
 
     # Functions to read realtime VOLTAGE, CURRENT and POWER from the power supply
     def getVoltage(self):

--- a/scpi_commands.py
+++ b/scpi_commands.py
@@ -18,6 +18,8 @@ POWER_SUPPLY_COMMANDS = {
     "setCurrentProt": "SOUR:CURR:PROT:HIGH {amps}",
     "setCurrentSlew": "SOUR:CURR:SLEW {amps}",
     "setPowerProt": "SOUR:POW:PROT:HIGH {watts}",
+    "setDC_Rise": "SOUR:VOLT:RISE {rate}",
+    "setDC_Fall": "SOUR:VOLT:FALL {rate}",
     "getVoltage": "FETCH:VOLT?",
     "getCurrent": "FETCH:CURR?",
     "getPower": "FETCH:POW?",


### PR DESCRIPTION
## Summary
- replace placeholder DC rise/fall implementations with `SOUR:VOLT:RISE` and `SOUR:VOLT:FALL`
- validate slew rate parameters in V/ms and document usage
- expose new rise/fall SCPI mappings

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689dd2cd6150832595e0c1c8a78b0dc0