### PR TITLE
Allow overriding instrument VISA resource names

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -19,17 +19,24 @@ class TestController:
     # Variable for keeping track of the C-rate of the battery
 
     # Initiating function
-    def __init__(self, multimeter_mode: str | None = None, debug: bool = False) -> None:
+    def __init__(
+        self,
+        multimeter_mode: str | None = None,
+        debug: bool = False,
+        ps_resource: str | None = None,
+        el_resource: str | None = None,
+        mm_resource: str | None = None,
+    ) -> None:
         self.multimeter_mode = multimeter_mode
         self.debug = debug
         try:
             # Trying to connect to the real device controllers
-            self.powerSupplyController = PowerSupplyController()
+            self.powerSupplyController = PowerSupplyController(ps_resource)
             print("Testcontroller succesfully connected to Power Supply")
-            self.electronicLoadController = ElectronicLoadController()
+            self.electronicLoadController = ElectronicLoadController(el_resource)
             print("Testcontroller succesfully connected to Electronic Load")
             if multimeter_mode:
-                self.multimeterController = MultimeterController()
+                self.multimeterController = MultimeterController(mm_resource)
                 print("Testcontroller succesfully connected to Multimeter")
                 if multimeter_mode == "tcouple":
                     self.multimeterController.configure_thermocouple()

--- a/AlIonTestSoftwareDeviceDrivers.py
+++ b/AlIonTestSoftwareDeviceDrivers.py
@@ -5,13 +5,15 @@ import pyvisa
 # Class for communication with the NI-VISA driver to control the power supply
 class PowerSupplyController:
     """Control a Chroma 62000P power supply via SCPI commands."""
-    # Variable to keep the resource name of the power supply
+    # Default NI-VISA resource name
     powerSupplyName = "USB0::0x1698::0x0837::011000000136::INSTR"
 
     # Constructor that establishes connection to the power supply
-    def __init__(self) -> None:
+    # ``resource_name`` may override the default VISA resource string.
+    def __init__(self, resource_name: str | None = None) -> None:
         self.resourceManager = pyvisa.ResourceManager()
-        self.powerSupply = self.resourceManager.open_resource(self.powerSupplyName)
+        name = resource_name or self.powerSupplyName
+        self.powerSupply = self.resourceManager.open_resource(name)
         
 
     # Function that returns the name of connected device
@@ -122,13 +124,14 @@ class PowerSupplyController:
 # Class for communication with the NI-VISA driver to control the electronic load
 class ElectronicLoadController:
     """Interface to a Chroma 63600 electronic load for discharging cells."""
-    # Variable to keep the resource name of the electronic load
+    # Default NI-VISA resource name
     electronicLoadName = "USB0::0x0A69::0x083E::000000000001::INSTR"
 
     # Constructor that establishes connection to the electronic load
-    def __init__(self) -> None:
+    def __init__(self, resource_name: str | None = None) -> None:
         self.resourceManager = pyvisa.ResourceManager()
-        self.electronicLoad = self.resourceManager.open_resource(self.electronicLoadName)
+        name = resource_name or self.electronicLoadName
+        self.electronicLoad = self.resourceManager.open_resource(name)
 
         # Set and activate the channel that will be used for testing
         self.electronicLoad.write("CHAN 1")
@@ -214,14 +217,14 @@ class ElectronicLoadController:
 # Class for communication with the NI-VISA driver to control the multimeter
 class MultimeterController:
     """Read measurements from a Chroma 51101 multimeter."""
-    
-    # Variable to keep the resource name of the mutimeter
+    # Default NI-VISA resource name
     multimeterName = "USB0::0x1698::0x083F::TW00014586::INSTR"
 
     # Constructor that establishes connection to the multimeter
-    def __init__(self) -> None:
+    def __init__(self, resource_name: str | None = None) -> None:
         self.resourceManager = pyvisa.ResourceManager()
-        self.multimeter = self.resourceManager.open_resource(self.multimeterName)
+        name = resource_name or self.multimeterName
+        self.multimeter = self.resourceManager.open_resource(name)
 
     # Function that returns the name of the connected device
     def checkDeviceConnection(self):

--- a/MAIN.py
+++ b/MAIN.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 import argparse
 import json
+import os
 from pathlib import Path
 from AlIonBatteryTestSoftware import TestController
 
@@ -72,8 +73,17 @@ def load_config(config_path: str, profile: str) -> dict:
 
 
 class TestTypes:
-    def __init__(self, multimeter_mode: str | None = None, debug: bool = False):
-        self.testController = TestController(multimeter_mode, debug)
+    def __init__(
+        self,
+        multimeter_mode: str | None = None,
+        debug: bool = False,
+        ps_resource: str | None = None,
+        el_resource: str | None = None,
+        mm_resource: str | None = None,
+    ):
+        self.testController = TestController(
+            multimeter_mode, debug, ps_resource, el_resource, mm_resource
+        )
         self.upsThread = None
 
     def runUPSTest(self, settings: UPSSettings):
@@ -118,6 +128,9 @@ def main():
     parser.add_argument("--config-file", help="JSON file with cell settings")
     parser.add_argument("--profile", help="cell profile name in config file")
     parser.add_argument("--capacity-config", help="JSON defaults for capacity test")
+    parser.add_argument("--ps-resource", help="VISA resource name for power supply")
+    parser.add_argument("--el-resource", help="VISA resource name for electronic load")
+    parser.add_argument("--mm-resource", help="VISA resource name for multimeter")
     parser.add_argument("--test-name")
     parser.add_argument("--temperature", type=float)
     parser.add_argument("--charge-volt-prot", type=int)
@@ -193,6 +206,22 @@ def main():
     if args.config_file:
         config = load_config(args.config_file, profile)
 
+    ps_resource = (
+        args.ps_resource
+        or os.getenv("POWER_SUPPLY_RESOURCE")
+        or config.get("ps_resource")
+    )
+    el_resource = (
+        args.el_resource
+        or os.getenv("ELECTRONIC_LOAD_RESOURCE")
+        or config.get("el_resource")
+    )
+    mm_resource = (
+        args.mm_resource
+        or os.getenv("MULTIMETER_RESOURCE")
+        or config.get("mm_resource")
+    )
+
     capacity_defaults = {}
     if args.capacity_config:
         try:
@@ -253,7 +282,7 @@ def main():
         finish_current = capacity_defaults.get("finish_current", 1.5)
 
     if args.actual_capacity_test:
-        tc = TestController(multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
         tc.actual_capacity_test(
             cap_charge_current,
             cap_discharge_current,
@@ -264,7 +293,7 @@ def main():
             finish_current,
         )
     elif args.efficiency_test:
-        tc = TestController(multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
         tc.efficiency_test(
             charge_current_max,
             dcharge_current_max,
@@ -274,7 +303,7 @@ def main():
         )
     elif args.rate_characteristic_test:
         rates = [float(r) for r in args.rates.split(',') if r]
-        tc = TestController(multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
         tc.rate_characteristic_test(
             rates,
             charge_current_max,
@@ -283,7 +312,7 @@ def main():
             temperature,
         )
     elif args.ocv_curve_test:
-        tc = TestController(multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
         tc.ocv_curve_test(
             args.step_current,
             args.steps,
@@ -291,7 +320,7 @@ def main():
             temperature,
         )
     elif args.internal_resistance_test:
-        tc = TestController(multimeter_mode, args.debug)
+        tc = TestController(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
         tc.internal_resistance_test(
             args.pulse_current,
             args.pulse_duration,
@@ -316,7 +345,7 @@ def main():
                 kwargs[field] = val
         settings = UPSSettings(**kwargs)
 
-        TObj = TestTypes(multimeter_mode, args.debug)
+        TObj = TestTypes(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
         thread = TObj.runUPSTest(settings)
         try:
             while thread.is_alive():

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ python MAIN.py
    continue using mock drivers.
    Use the `-d` flag to print detailed progress messages during a test.
 
+### Instrument resource names
+
+The scripts use preset NI-VISA resource names for the power supply,
+electronic load and multimeter.  These can be overridden:
+
+* Command line options `--ps-resource`, `--el-resource` and `--mm-resource`
+* Environment variables `POWER_SUPPLY_RESOURCE`,
+  `ELECTRONIC_LOAD_RESOURCE` and `MULTIMETER_RESOURCE`
+* Keys `ps_resource`, `el_resource` and `mm_resource` in the selected
+  JSON configuration profile
+
+If none of these are provided the built-in defaults are used.
+
 To perform a full capacity measurement instead of the default cycling test run:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add optional VISA resource name parameters to instrument drivers and TestController
- Parse instrument resource overrides from CLI flags, environment variables, or JSON profiles in `MAIN.py`
- Document resource name configuration in README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689dd2d9a29c832584ef61134c67d87a