### PR TITLE
Remove deprecated use-multimeter flag

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -196,11 +196,6 @@ def main():
         help="log measurement with multimeter (voltage or thermocouple)"
     )
     parser.add_argument(
-        "--use-multimeter",
-        action="store_true",
-        help="DEPRECATED: same as --multimeter-mode voltage"
-    )
-    parser.add_argument(
         "-d",
         "--debug",
         action="store_true",
@@ -208,9 +203,6 @@ def main():
     )
 
     args = parser.parse_args()
-
-    if args.multimeter_mode is None and args.use_multimeter:
-        args.multimeter_mode = "tcouple"
 
     profile = args.profile or args.test_name or TEST_NAME
     config = {}
@@ -271,8 +263,6 @@ def main():
     multimeter_mode = args.multimeter_mode
     if multimeter_mode is None:
         multimeter_mode = capacity_defaults.get("multimeter_mode")
-        if multimeter_mode is None and args.use_multimeter:
-            multimeter_mode = "voltage"
 
     cap_charge_volt = args.capacity_charge_voltage
     if cap_charge_volt is None:

--- a/README.md
+++ b/README.md
@@ -228,6 +228,11 @@ python -m py_compile *.py
 
 at the repository root. This ensures all Python files compile cleanly.
 
+## Breaking Changes
+
+- The `--use-multimeter` flag has been removed. Use `--multimeter-mode` to enable
+  multimeter logging.
+
 ## Stopping a running test
 
 Press `Ctrl+C` while a test is active to abort safely. The program turns off


### PR DESCRIPTION
## Summary
- drop `--use-multimeter` argument and related code paths
- document flag removal and direct users to `--multimeter-mode`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689ddc71f8388325848731fcabde4434