### PR TITLE
Unify UPS and capacity configuration

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -63,13 +63,15 @@ class UPSSettings:
     multimeter_mode: str | None = None
 
 
-def load_config(config_path: str, profile: str) -> dict:
-    """Load settings for a given cell profile from a JSON configuration file."""
+def load_config(config_path: str, profile: str) -> tuple[dict, dict]:
+    """Load profile settings and capacity defaults from a JSON file."""
     try:
         data = json.loads(Path(config_path).read_text())
-        return data.get(profile, {}) if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            return {}, {}
+        return data.get(profile, {}), data.get("capacity_defaults", {})
     except Exception:
-        return {}
+        return {}, {}
 
 
 class TestTypes:
@@ -127,7 +129,6 @@ def main():
     parser = argparse.ArgumentParser(description="Run UPS test")
     parser.add_argument("--config-file", help="JSON file with cell settings")
     parser.add_argument("--profile", help="cell profile name in config file")
-    parser.add_argument("--capacity-config", help="JSON defaults for capacity test")
     parser.add_argument("--ps-resource", help="VISA resource name for power supply")
     parser.add_argument("--el-resource", help="VISA resource name for electronic load")
     parser.add_argument("--mm-resource", help="VISA resource name for multimeter")
@@ -214,8 +215,9 @@ def main():
 
     profile = args.profile or args.test_name or TEST_NAME
     config = {}
+    capacity_defaults = {}
     if args.config_file:
-        config = load_config(args.config_file, profile)
+        config, capacity_defaults = load_config(args.config_file, profile)
 
     ps_resource = (
         args.ps_resource
@@ -233,13 +235,6 @@ def main():
         or config.get("mm_resource")
     )
 
-    capacity_defaults = {}
-    if args.capacity_config:
-        try:
-            capacity_defaults = json.loads(Path(args.capacity_config).read_text())
-        except Exception as exc:
-            print(f"Failed to load capacity config: {exc}")
-            capacity_defaults = {}
 
     for field in UPSSettings.__annotations__.keys():
         if getattr(args, field) is None:
@@ -372,4 +367,4 @@ if __name__ == "__main__":
 # This allows running the script directly from the command line
 # Example usage:
 # python MAIN.py --actual-capacity-test --capacity-charge-current 4.6 --capacity-discharge-current 46 --multimeter-mode tcouple
-# python MAIN.py --actual-capacity-test --capacity-config tests/capacity_defaults.json -d
+# python MAIN.py --actual-capacity-test --config-file cell_profiles.json -d

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install pyvisa pandas openpyxl matplotlib tabulate
 1. Connect the Chroma 63600 electronic load and Chroma 62000P power supply to
    your PC and ensure the NI-VISA drivers are installed.
 2. Adjust the charge/discharge parameters using command-line options, or
-   provide a JSON configuration file with cell profiles.
+   provide a JSON configuration file with cell profiles and capacity defaults.
 3. Run the test script:
 
 ```bash
@@ -62,20 +62,15 @@ python MAIN.py --actual-capacity-test \
 ```
 ``--capacity-charge-voltage`` defaults to the value of ``--charge-volt-end``
 (or ``4.1``&nbsp;V). ``--capacity-rest-time`` and ``--capacity-min-voltage``
-fall back to the values in the file passed with ``--capacity-config`` or,
-if that option is omitted, to one hour and ``2.75``&nbsp;V respectively.
+fall back to the values in the ``capacity_defaults`` section of the JSON
+file passed with ``--config-file`` or, if that section is absent, to one
+hour and ``2.75``&nbsp;V respectively.
 
-You can also supply defaults for the capacity test via a JSON file:
-
-```bash
-python MAIN.py --actual-capacity-test --capacity-config tests/capacity_defaults.json
-```
-
-The file may define ``rest_time``, ``charge_voltage``, ``min_voltage``,
-``charge_current``, ``discharge_current``, ``finish_current`` and
-``multimeter_mode`` keys.
-These values override the built‑in defaults in ``MAIN.py`` but any
-command-line options still take precedence.
+The configuration file may define ``rest_time``, ``charge_voltage``,
+``min_voltage``, ``charge_current``, ``discharge_current``,
+``finish_current`` and ``multimeter_mode`` keys inside
+``capacity_defaults``. These values override the built‑in defaults in
+``MAIN.py`` but any command-line options still take precedence.
 
 Additional tests can be invoked with the following flags:
 
@@ -120,7 +115,8 @@ Additional tests can be invoked with the following flags:
 
 Instead of specifying every parameter on the command line you can store
 cell profiles in a JSON file. A sample `cell_profiles.json` is included in
-the repository. Select a profile like this:
+the repository. It also contains a ``capacity_defaults`` section used for
+standalone capacity tests. Select a profile like this:
 
 ```bash
 python MAIN.py --config-file cell_profiles.json --profile YUASA

--- a/cell_profiles.json
+++ b/cell_profiles.json
@@ -1,4 +1,13 @@
 {
+  "capacity_defaults": {
+    "rest_time": 60,
+    "charge_voltage": 4.1,
+    "min_voltage": 2.75,
+    "charge_current": 46.0,
+    "finish_current": 1.5,
+    "discharge_current": 46.0,
+    "multimeter_mode": "tcouple"
+  },
   "YUASA": {
     "charge_volt_start": 4.1,
     "charge_volt_end": 4.1,

--- a/tests/capacity_defaults.json
+++ b/tests/capacity_defaults.json
@@ -1,9 +1,0 @@
-{
-  "rest_time": 60,
-  "charge_voltage": 4.1,
-  "min_voltage": 2.75,
-  "charge_current": 46.0,
-  "finish_current": 1.5,
-  "discharge_current": 46.0,
-  "multimeter_mode": "tcouple"
-}


### PR DESCRIPTION
## Summary
- Consolidate UPS profile and capacity defaults into a single JSON configuration
- Load capacity defaults from `capacity_defaults` in config and drop `--capacity-config` flag
- Update documentation and examples for unified configuration handling

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689ddec9a0708325bb1fca1e7da447ae