### PR TITLE
Fix config and capacity defaults loading

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -209,8 +209,9 @@ def main():
 
     profile = args.profile or args.test_name or TEST_NAME
     config = {}
+    capacity_defaults = {}
     if args.config_file:
-        config = load_config(args.config_file, profile)
+        config, capacity_defaults = load_config(args.config_file, profile)
 
     ps_resource = (
         args.ps_resource


### PR DESCRIPTION
## Summary
- Initialize `config` and `capacity_defaults` before loading configuration
- Unpack `load_config` results to populate both dictionaries

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689df27f56c483259b0619c4960c66c5