### PR TITLE
Refine power protection interface

### DIFF
--- a/AlIonTestSoftwareDeviceDrivers.py
+++ b/AlIonTestSoftwareDeviceDrivers.py
@@ -74,8 +74,8 @@ class PowerSupplyController:
     #     self.powerSupply.write("SOUR:CURR:LIMIT:HIGH MAX")  # Could not find MAX command in manual
 
     #### POWER #### POWER #### POWER #### POWER #### POWER ####
-    def setPowerProt(self, *watt):
-        self.powerSupply.write("SOUR:POW:PROT:HIGH " + str(watt[0]))
+    def setPowerProt(self, watts: float) -> None:
+        self.powerSupply.write("SOUR:POW:PROT:HIGH " + str(watts))
 
     # def setPowerMax(self):
     #     self.powerSupply.write("SOUR:POW:PROT:HIGH MAX")  # Could not find MAX command in manual


### PR DESCRIPTION
## Summary
- Simplify power protection configuration in `PowerSupplyController` to accept a single `watts` float and write it directly

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689dfadafb04832599ee1d5e0a9a9bbb