### PR TITLE
refactor: remove unused tkinter import from mock drivers

### DIFF
--- a/AlIonTestSoftwareDeviceDriversMock.py
+++ b/AlIonTestSoftwareDeviceDriversMock.py
@@ -1,7 +1,6 @@
 """Mock implementations of the device drivers for testing without hardware."""
 
 from random import randrange
-import tkinter
 
 # Class for communication with the NI-VISA driver to control the power supply
 class PowerSupplyControllerMock:


### PR DESCRIPTION
## Summary
- remove unused tkinter import from mock device drivers

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689dfae2ab248325b5851a9cf6fc0358