### PR TITLE
Handle specific errors when loading config

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -67,11 +67,16 @@ def load_config(config_path: str, profile: str) -> tuple[dict, dict]:
     """Load profile settings and capacity defaults from a JSON file."""
     try:
         data = json.loads(Path(config_path).read_text())
-        if not isinstance(data, dict):
-            return {}, {}
-        return data.get(profile, {}), data.get("capacity_defaults", {})
-    except Exception:
+    except FileNotFoundError:
+        print(f"Configuration file not found: {config_path}")
         return {}, {}
+    except json.JSONDecodeError as exc:
+        print(f"Error decoding JSON from {config_path}: {exc}")
+        return {}, {}
+
+    if not isinstance(data, dict):
+        return {}, {}
+    return data.get(profile, {}), data.get("capacity_defaults", {})
 
 
 


### PR DESCRIPTION
## Summary
- handle missing config and JSON parse errors in `load_config`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689dfaec95c083259a8c2815f8463717