### PR TITLE
feat: configure mock drivers without prompt

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime
 from datetime import timedelta
 import threading
+import os
 from AlIonTestSoftwareDeviceDrivers import PowerSupplyController, ElectronicLoadController, MultimeterController
 from AlIonTestSoftwareDeviceDriversMock import PowerSupplyControllerMock, ElectronicLoadControllerMock, MultimeterControllerMock
 from AlIonTestSoftwareDataManagement import DataStorage
@@ -35,39 +36,40 @@ class TestController:
         ps_resource: str | None = None,
         el_resource: str | None = None,
         mm_resource: str | None = None,
+        use_mock: bool | None = None,
     ) -> None:
         self.multimeter_mode = multimeter_mode
         self.debug = debug
-        try:
-            # Trying to connect to the real device controllers
-            self.powerSupplyController = PowerSupplyController(ps_resource)
-            print("Testcontroller succesfully connected to Power Supply")
-            self.electronicLoadController = ElectronicLoadController(el_resource)
-            print("Testcontroller succesfully connected to Electronic Load")
-            if multimeter_mode:
-                self.multimeterController = MultimeterController(mm_resource)
-                print("Testcontroller succesfully connected to Multimeter")
-                if multimeter_mode == "tcouple":
-                    self.multimeterController.configure_thermocouple()
+        if use_mock is None:
+            env = os.getenv("USE_MOCK_DRIVERS")
+            if env is not None:
+                use_mock = env.lower() in ("1", "true", "yes")
             else:
-                self.multimeterController = MultimeterControllerMock()
-        except Exception:
-            # Connecting to the mock device controllers when the real devices
-            # are not available.  The previous implementation exited before the
-            # mock controllers were created which made running the software
-            # without hardware impossible.
-            print("Connection not successful.")
-            answer = input(
-                "Devices not detected. Continue with mock drivers? [y/N]: "
-            ).strip().lower()
-            if answer not in ("y", "yes"):
-                raise SystemExit(
-                    "Aborting: no connection to hardware and user declined mock drivers"
-                )
+                use_mock = False
+
+        if use_mock:
             print("Using mock objects")
             self.powerSupplyController = PowerSupplyControllerMock()
             self.electronicLoadController = ElectronicLoadControllerMock()
             self.multimeterController = MultimeterControllerMock()
+        else:
+            try:
+                # Trying to connect to the real device controllers
+                self.powerSupplyController = PowerSupplyController(ps_resource)
+                print("Testcontroller succesfully connected to Power Supply")
+                self.electronicLoadController = ElectronicLoadController(el_resource)
+                print("Testcontroller succesfully connected to Electronic Load")
+                if multimeter_mode:
+                    self.multimeterController = MultimeterController(mm_resource)
+                    print("Testcontroller succesfully connected to Multimeter")
+                    if multimeter_mode == "tcouple":
+                        self.multimeterController.configure_thermocouple()
+                else:
+                    self.multimeterController = MultimeterControllerMock()
+            except Exception as exc:
+                raise SystemExit(
+                    "Aborting: no connection to hardware and mock drivers disabled"
+                ) from exc
 
         # Create an event to indicate if test is running
         self.event = threading.Event()

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ pip install pyvisa pandas openpyxl matplotlib tabulate
 ```bash
 python MAIN.py
 ```
-   If no hardware connection is detected the program will ask whether to
-   continue using mock drivers.
+   If no hardware connection is detected the program aborts unless mock
+   drivers are enabled. Set the environment variable `USE_MOCK_DRIVERS=1`
+   to force the built‑in mock drivers for development without hardware.
    Use the `-d` flag to print detailed progress messages during a test.
 
 ### Instrument resource names


### PR DESCRIPTION
## Summary
- add `use_mock` flag and `USE_MOCK_DRIVERS` env var to TestController
- document new environment variable in README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689dfaf00fb88325b72783a4a95f8190