### PR TITLE
Refine pandas imports and error handling

### DIFF
--- a/AlIonTestSoftwareDataManagement.py
+++ b/AlIonTestSoftwareDataManagement.py
@@ -5,8 +5,8 @@ from openpyxl.chart import ScatterChart, Reference, Series  # type: ignore
 # from openpyxl.chart.series import Series
 from datetime import datetime
 import os
-import pandas
 import pandas as pd
+from pandas import errors as pd_errors
 import math
 import statistics
 
@@ -155,7 +155,7 @@ class DataStorage:
                 self.exportXLSXFile(filePath, chargeTime, timeInterval)
                 if verbose:
                     print(f"Charge time configured: {chargeTime}")
-        except (OSError, pandas.errors.PandasError) as err:
+        except (OSError, pd_errors.PandasError) as err:
             print(f"Data storage failed: {err}")
         # Empty the result values
         self.time = []


### PR DESCRIPTION
## Summary
- streamline pandas usage by importing as pd only and aliasing pandas.errors
- update exception handling to use pd_errors.PandasError

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689e0006f36483258d848785ac0112d8