### PR TITLE
Prompt test type in build_test_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,10 @@ python MAIN.py --config-file cell_profiles.json --profile YUASA
 
 Command-line options still override the values loaded from the profile.
 
-An interactive helper `build_test_config.py` prompts for UPS settings and
-capacity‑test parameters and writes a JSON file with a top-level
-`ups_settings` and `capacity_test` section.  The script saves the file under
+An interactive helper `build_test_config.py` first asks for a test name and
+which type of test to configure (UPS, capacity or both).  It then prompts only
+for the relevant parameters and writes a JSON file containing the selected
+sections under a top-level `test_name`.  The script saves the file under
 `configs/` using a name you choose.
 
 This charges the cell at 1C up to the voltage specified by

--- a/build_test_config.py
+++ b/build_test_config.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 """Interactive helper to create UPS and capacity test configuration files.
 
-The generated JSON file uses the following structure:
-{
-  "ups_settings": {...},
-  "capacity_test": {...}
-}
+The script first asks for a ``test_name`` and which type of test to
+configure.  Depending on the chosen type it prompts only for the
+relevant parameters and writes a JSON file using this structure::
+
+    {
+      "test_name": "...",
+      "ups_settings": {...},    # optional
+      "capacity_test": {...}    # optional
+    }
 """
 
 import json
@@ -13,8 +17,8 @@ from pathlib import Path
 from typing import Callable, Any
 
 # Default UPS settings matching MAIN.py constants
+DEFAULT_TEST_NAME = "YUASA"
 UPS_DEFAULTS = {
-    "test_name": "YUASA",
     "temperature": 23.4,
     "charge_volt_prot": 10,
     "charge_current_prot": 100,
@@ -85,9 +89,9 @@ def _prompt_number(prompt: str, caster: Callable[[str], Any], *, default: Any, m
             print(f"Enter a value between {minimum} and {maximum}.")
 
 
-def build_ups_settings() -> dict:
+def build_ups_settings(test_name: str) -> dict:
     """Collect UPS settings from the user with range validation."""
-    ups = {}
+    ups = {"test_name": test_name}
     for field, default in UPS_DEFAULTS.items():
         if isinstance(default, (int, float)):
             minimum, maximum = UPS_RANGES.get(field, (0, 1e9))
@@ -113,11 +117,17 @@ def build_capacity_settings() -> dict:
 
 
 def main() -> None:
-    print("Enter UPS settings:")
-    ups_settings = build_ups_settings()
-    print("\nEnter capacity test parameters:")
-    capacity_settings = build_capacity_settings()
-    config = {"ups_settings": ups_settings, "capacity_test": capacity_settings}
+    test_name = input(f"test_name [{DEFAULT_TEST_NAME}]: ").strip() or DEFAULT_TEST_NAME
+    test_type = input("Test type (ups, capacity, both) [ups]: ").strip().lower() or "ups"
+    config = {"test_name": test_name}
+    if test_type in ("ups", "both"):
+        print("Enter UPS settings:")
+        ups_settings = build_ups_settings(test_name)
+        config["ups_settings"] = ups_settings
+    if test_type in ("capacity", "both"):
+        print("\nEnter capacity test parameters:")
+        capacity_settings = build_capacity_settings()
+        config["capacity_test"] = capacity_settings
     print("\nGenerated configuration:")
     print(json.dumps(config, indent=2))
     filename = input("\nSave under configs/ as (without extension): ").strip() or "test_config"


### PR DESCRIPTION
## Summary
- Ask for test name and type before gathering configuration parameters
- Only prompt for UPS and/or capacity settings based on chosen test type
- Document new behaviour of build_test_config.py in README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689e050181d8832581a1c2e222d53df3