### PR TITLE
Refactor UPS test into custom test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ The project is organised as a set of Python modules used to run charging/dischar
 | File | Purpose |
 | --- | --- |
 | `MAIN.py` | Command line interface and entry point. Parses arguments, loads configuration from `cell_profiles.json` and invokes tests in `TestController`. |
-| `AlIonBatteryTestSoftware.py` | Implements `TestController` coordinating the power supply, electronic load and multimeter. Contains high level test routines such as UPS tests, efficiency tests and capacity measurements. |
+| `AlIonBatteryTestSoftware.py` | Implements `TestController` coordinating the power supply, electronic load and multimeter. Contains high level test routines such as custom tests, efficiency tests and capacity measurements. |
 | `AlIonTestSoftwareDataManagement.py` | Provides the `DataStorage` class used to store and export measurement data to CSV/Excel and to create graphs. |
 | `AlIonTestSoftwareDeviceDrivers.py` | Low level device drivers using NI-VISA to control the power supply, electronic load and multimeter. |
 | `AlIonTestSoftwareDeviceDriversMock.py` | Mock versions of the device drivers for running the software without hardware attached. |
@@ -28,7 +28,7 @@ The project is organised as a set of Python modules used to run charging/dischar
 ### Main modules
 
 **TestController** (`AlIonBatteryTestSoftware.py`)
-: Handles test execution. It exposes functions like `NEWupsTest`, `efficiency_test`, `rate_characteristic_test`, `internal_resistance_test` and `actual_capacity_test`. These routines send commands to the instrument drivers and log measurements via `DataStorage`.
+: Handles test execution. It exposes functions like `custom_test`, `efficiency_test`, `rate_characteristic_test`, `internal_resistance_test` and `actual_capacity_test`. These routines send commands to the instrument drivers and log measurements via `DataStorage`.
 
 **DataStorage** (`AlIonTestSoftwareDataManagement.py`)
 : Collects timestamps, voltage, current, power and optional capacity or multimeter readings. `createTable()` writes a CSV file and optionally an Excel workbook with graphs.

--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -1,4 +1,4 @@
-"""Core routines for controlling UPS battery test sequences."""
+"""Core routines for controlling custom battery test sequences."""
 
 import time
 from datetime import datetime
@@ -322,8 +322,8 @@ class TestController:
 
     # Test protocal for testing the capacity of a battery
 
-# This function is called from the TestTypes class to run a UPS test
-    def NEWupsTest(
+# This function is called from the TestTypes class to run a custom test
+    def custom_test(
         self,
         test_name: str,
         temperature: float,

--- a/AlIonTestSoftwareDataManagement.py
+++ b/AlIonTestSoftwareDataManagement.py
@@ -345,4 +345,4 @@ class DataStorage:
 
 # Notað til að keyra sjálfvirk gröf á utanaðkomandi csv skrár
 # dataStorage = DataStorage()
-# dataStorage.exportXLSXFile("C:/Users/runson/Dropbox/Sharing/Alor test/UPS Test for 1C nr. 2 at 20° celsius     03_01_2023 15_21_10",chargeTime="180",timeInterval=0.2)
+# dataStorage.exportXLSXFile("C:/Users/runson/Dropbox/Sharing/Alor test/custom test for 1C nr. 2 at 20° celsius     03_01_2023 15_21_10",chargeTime="180",timeInterval=0.2)

--- a/MAIN.py
+++ b/MAIN.py
@@ -1,4 +1,4 @@
-"""Command line interface for running UPS battery tests."""
+"""Command line interface for running custom battery tests."""
 
 from dataclasses import dataclass
 import argparse
@@ -42,8 +42,8 @@ TEMPERATURE: float = 23.4    # °C
 
 
 @dataclass
-class UPSSettings:
-    """Configuration for a UPS test run."""
+class CustomTestSettings:
+    """Configuration for a custom test run."""
 
     test_name: str = TEST_NAME
     temperature: float = TEMPERATURE
@@ -93,14 +93,14 @@ class TestTypes:
         self.testController = TestController(
             multimeter_mode, debug, ps_resource, el_resource, mm_resource
         )
-        self.upsThread = None
+        self.custom_thread = None
 
-    def runUPSTest(self, settings: UPSSettings):
-        """Start a UPS test using the provided settings."""
+    def run_custom_test(self, settings: CustomTestSettings):
+        """Start a custom test using the provided settings."""
         import threading
         self.testController.event.clear()
-        self.upsThread = threading.Thread(
-            target=self.testController.NEWupsTest,
+        self.custom_thread = threading.Thread(
+            target=self.testController.custom_test,
             args=(
                 settings.test_name,
                 settings.temperature,
@@ -121,19 +121,19 @@ class TestTypes:
                 settings.multimeter_mode,
             ),
         )
-        self.upsThread.start()
-        return self.upsThread
+        self.custom_thread.start()
+        return self.custom_thread
 
     def stop(self):
         """Abort the running test and wait for it to finish."""
         if self.testController:
             self.testController.abort()
-        if self.upsThread is not None:
-            self.upsThread.join()
+        if self.custom_thread is not None:
+            self.custom_thread.join()
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Run UPS test")
+    parser = argparse.ArgumentParser(description="Run custom test")
     parser.add_argument("--config-file", help="JSON file with cell settings")
     parser.add_argument("--profile", help="cell profile name in config file")
     parser.add_argument("--ps-resource", help="VISA resource name for power supply")
@@ -236,7 +236,7 @@ def main():
     )
 
 
-    for field in UPSSettings.__annotations__.keys():
+    for field in CustomTestSettings.__annotations__.keys():
         if getattr(args, field) is None:
             if field in config:
                 setattr(args, field, config[field])
@@ -343,14 +343,14 @@ def main():
 
     else:
         kwargs = {}
-        for field in UPSSettings.__annotations__.keys():
+        for field in CustomTestSettings.__annotations__.keys():
             val = getattr(args, field, None)
             if val is not None:
                 kwargs[field] = val
-        settings = UPSSettings(**kwargs)
+        settings = CustomTestSettings(**kwargs)
 
         TObj = TestTypes(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
-        thread = TObj.runUPSTest(settings)
+        thread = TObj.run_custom_test(settings)
         try:
             while thread.is_alive():
                 thread.join(0.5)

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 This project contains Python scripts for automated charging and discharging tests.
 It communicates with a **Chroma 63600 Modular DC Electronic Load**, a
 **Chroma 62000P Programmable DC Power Supply** and a **Chroma 12061 multimeter**
-to perform UPS battery cycling and log the resulting data.
+to perform custom battery cycling and log the resulting data.
 
 ## Project structure
 
 | File | Purpose |
 | --- | --- |
 | `MAIN.py` | Command-line interface and entry point. Parses arguments, loads configuration from `cell_profiles.json` and invokes tests in `TestController`. |
-| `AlIonBatteryTestSoftware.py` | Implements `TestController`, coordinating the power supply, electronic load and multimeter. Contains high level test routines such as UPS tests, efficiency tests and capacity measurements. |
+| `AlIonBatteryTestSoftware.py` | Implements `TestController`, coordinating the power supply, electronic load and multimeter. Contains high level test routines such as custom tests, efficiency tests and capacity measurements. |
 | `AlIonTestSoftwareDataManagement.py` | Provides the `DataStorage` class used to store and export measurement data to CSV/Excel and to create graphs. |
 | `AlIonTestSoftwareDeviceDrivers.py` | Low level device drivers using NI-VISA to control the power supply, electronic load and multimeter. |
 | `AlIonTestSoftwareDeviceDriversMock.py` | Mock versions of the device drivers for running the software without hardware attached. |
-| `build_test_config.py` | Interactive helper that writes JSON files with UPS and capacity-test settings. |
+| `build_test_config.py` | Interactive helper that writes JSON files with custom and capacity-test settings. |
 | `scpi_commands.py` | Quick reference of SCPI command strings used by the drivers. |
 | `cell_profiles.json` | Example configuration profiles containing default test parameters. |
 | `manuals/` | Manufacturer programming manuals (not tracked by version control). |
@@ -141,7 +141,7 @@ python MAIN.py --config-file cell_profiles.json --profile YUASA
 Command-line options still override the values loaded from the profile.
 
 An interactive helper `build_test_config.py` first asks for a test name and
-which type of test to configure (UPS, capacity or both).  It then prompts only
+which type of test to configure (custom, capacity or both).  It then prompts only
 for the relevant parameters and writes a JSON file containing the selected
 sections under a top-level `test_name`.  The script saves the file under
 `configs/` using a name you choose.

--- a/build_test_config.py
+++ b/build_test_config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Interactive helper to create UPS and capacity test configuration files.
+"""Interactive helper to create custom and capacity test configuration files.
 
 The script first asks for a ``test_name`` and which type of test to
 configure.  Depending on the chosen type it prompts only for the
@@ -7,7 +7,7 @@ relevant parameters and writes a JSON file using this structure::
 
     {
       "test_name": "...",
-      "ups_settings": {...},    # optional
+      "custom_settings": {...},    # optional
       "capacity_test": {...}    # optional
     }
 """
@@ -16,9 +16,9 @@ import json
 from pathlib import Path
 from typing import Callable, Any
 
-# Default UPS settings matching MAIN.py constants
+# Default custom test settings matching MAIN.py constants
 DEFAULT_TEST_NAME = "YUASA"
-UPS_DEFAULTS = {
+CUSTOM_DEFAULTS = {
     "temperature": 23.4,
     "charge_volt_prot": 10,
     "charge_current_prot": 100,
@@ -38,7 +38,7 @@ UPS_DEFAULTS = {
 }
 
 # Ranges for validation
-UPS_RANGES = {
+CUSTOM_RANGES = {
     "temperature": (-50, 150),
     "charge_volt_prot": (0, 1000),
     "charge_current_prot": (0, 1000),
@@ -89,18 +89,18 @@ def _prompt_number(prompt: str, caster: Callable[[str], Any], *, default: Any, m
             print(f"Enter a value between {minimum} and {maximum}.")
 
 
-def build_ups_settings(test_name: str) -> dict:
-    """Collect UPS settings from the user with range validation."""
-    ups = {"test_name": test_name}
-    for field, default in UPS_DEFAULTS.items():
+def build_custom_settings(test_name: str) -> dict:
+    """Collect custom test settings from the user with range validation."""
+    custom = {"test_name": test_name}
+    for field, default in CUSTOM_DEFAULTS.items():
         if isinstance(default, (int, float)):
-            minimum, maximum = UPS_RANGES.get(field, (0, 1e9))
+            minimum, maximum = CUSTOM_RANGES.get(field, (0, 1e9))
             caster = int if isinstance(default, int) and not isinstance(default, bool) else float
-            ups[field] = _prompt_number(field, caster, default=default, minimum=minimum, maximum=maximum)
+            custom[field] = _prompt_number(field, caster, default=default, minimum=minimum, maximum=maximum)
         else:
             val = input(f"{field} [{default if default is not None else 'none'}]: ")
-            ups[field] = val if val else default
-    return ups
+            custom[field] = val if val else default
+    return custom
 
 
 def build_capacity_settings() -> dict:
@@ -118,12 +118,12 @@ def build_capacity_settings() -> dict:
 
 def main() -> None:
     test_name = input(f"test_name [{DEFAULT_TEST_NAME}]: ").strip() or DEFAULT_TEST_NAME
-    test_type = input("Test type (ups, capacity, both) [ups]: ").strip().lower() or "ups"
+    test_type = input("Test type (custom, capacity, both) [custom]: ").strip().lower() or "custom"
     config = {"test_name": test_name}
-    if test_type in ("ups", "both"):
-        print("Enter UPS settings:")
-        ups_settings = build_ups_settings(test_name)
-        config["ups_settings"] = ups_settings
+    if test_type in ("custom", "both"):
+        print("Enter custom test settings:")
+        custom_settings = build_custom_settings(test_name)
+        config["custom_settings"] = custom_settings
     if test_type in ("capacity", "both"):
         print("\nEnter capacity test parameters:")
         capacity_settings = build_capacity_settings()


### PR DESCRIPTION
## Summary
- rename UPS test routine to `custom_test`
- update CLI and test runner to `run_custom_test`
- revise docs and helpers to reference custom tests instead of UPS tests

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689e08585dd88325b21f32977a04266d