### PR TITLE
Add profile test_type dispatch

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -64,20 +64,27 @@ class CustomTestSettings:
     multimeter_mode: str | None = None
 
 
-def load_config(config_path: str, profile: str) -> tuple[dict, dict]:
-    """Load profile settings and capacity defaults from a JSON file."""
+def load_config(config_path: str, profile: str) -> tuple[dict, dict, str | None]:
+    """Load profile parameters, capacity defaults and test type from a JSON file."""
     try:
         data = json.loads(Path(config_path).read_text())
     except FileNotFoundError:
         print(f"Configuration file not found: {config_path}")
-        return {}, {}
+        return {}, {}, None
     except json.JSONDecodeError as exc:
         print(f"Error decoding JSON from {config_path}: {exc}")
-        return {}, {}
+        return {}, {}, None
 
     if not isinstance(data, dict):
-        return {}, {}
-    return data.get(profile, {}), data.get("capacity_defaults", {})
+        return {}, {}, None
+
+    profile_data = data.get(profile, {})
+    if not isinstance(profile_data, dict):
+        return {}, data.get("capacity_defaults", {}), None
+
+    test_type = profile_data.get("test_type")
+    params = profile_data.get("parameters", {})
+    return params, data.get("capacity_defaults", {}), test_type
 
 
 
@@ -216,8 +223,9 @@ def main():
     profile = args.profile or args.test_name or TEST_NAME
     config = {}
     capacity_defaults = {}
+    test_type = None
     if args.config_file:
-        config, capacity_defaults = load_config(args.config_file, profile)
+        config, capacity_defaults, test_type = load_config(args.config_file, profile)
 
     ps_resource = (
         args.ps_resource
@@ -340,6 +348,84 @@ def main():
             finish_current,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")
+    elif args.config_file and test_type:
+        tc = TestController(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
+        if test_type == "actual_capacity_test":
+            tc.actual_capacity_test(
+                cap_charge_current,
+                cap_discharge_current,
+                rest_time,
+                cap_charge_volt,
+                cap_min_volt,
+                temperature,
+                finish_current,
+            )
+        elif test_type == "efficiency_test":
+            tc.efficiency_test(
+                charge_current_max,
+                dcharge_current_max,
+                charge_volt_end,
+                dcharge_volt_min,
+                temperature,
+            )
+        elif test_type == "rate_characteristic_test":
+            rates_cfg = config.get("rates", args.rates)
+            if isinstance(rates_cfg, str):
+                rates = [float(r) for r in rates_cfg.split(',') if r]
+            else:
+                rates = [float(r) for r in rates_cfg]
+            tc.rate_characteristic_test(
+                rates,
+                charge_current_max,
+                charge_volt_end,
+                dcharge_volt_min,
+                temperature,
+            )
+        elif test_type == "ocv_curve_test":
+            step_current = config.get("step_current", args.step_current)
+            steps = config.get("steps", args.steps)
+            tc.ocv_curve_test(
+                step_current,
+                steps,
+                1800.0,
+                temperature,
+            )
+        elif test_type == "internal_resistance_test":
+            pulse_current = config.get("pulse_current", args.pulse_current)
+            pulse_duration = config.get("pulse_duration", args.pulse_duration)
+            tc.internal_resistance_test(
+                pulse_current,
+                pulse_duration,
+                temperature,
+            )
+            capacity = tc.actual_capacity_test(
+                cap_charge_current,
+                cap_discharge_current,
+                rest_time,
+                cap_charge_volt,
+                cap_min_volt,
+                temperature,
+                finish_current,
+            )
+            print(f"Measured capacity: {capacity:.3f} Ah")
+        elif test_type == "custom":
+            kwargs = {}
+            for field in CustomTestSettings.__annotations__.keys():
+                val = getattr(args, field, None)
+                if val is not None:
+                    kwargs[field] = val
+            settings = CustomTestSettings(**kwargs)
+            TObj = TestTypes(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
+            thread = TObj.run_custom_test(settings)
+            try:
+                while thread.is_alive():
+                    thread.join(0.5)
+            except KeyboardInterrupt:
+                print("Keyboard interrupt received, stopping test")
+                TObj.stop()
+        else:
+            print(f"Unsupported test_type: {test_type}")
+            return
 
     else:
         kwargs = {}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to perform custom battery cycling and log the resulting data.
 | `AlIonTestSoftwareDeviceDriversMock.py` | Mock versions of the device drivers for running the software without hardware attached. |
 | `build_test_config.py` | Interactive helper that writes JSON files with custom and capacity-test settings. |
 | `scpi_commands.py` | Quick reference of SCPI command strings used by the drivers. |
-| `cell_profiles.json` | Example configuration profiles containing default test parameters. |
+| `cell_profiles.json` | Example configuration profiles containing test parameters and their `test_type`. |
 | `manuals/` | Manufacturer programming manuals (not tracked by version control). |
 
 ## Requirements
@@ -139,6 +139,11 @@ python MAIN.py --config-file cell_profiles.json --profile YUASA
 ```
 
 Command-line options still override the values loaded from the profile.
+
+Each profile defines a `test_type` such as `custom`, `efficiency_test` or
+`rate_characteristic_test` alongside its parameter block. When a configuration
+file and profile are supplied without explicit test flags, `MAIN.py` dispatches
+to the corresponding `TestController` method based on `test_type`.
 
 An interactive helper `build_test_config.py` first asks for a test name and
 which type of test to configure (custom, capacity or both).  It then prompts only

--- a/cell_profiles.json
+++ b/cell_profiles.json
@@ -9,42 +9,51 @@
     "multimeter_mode": "tcouple"
   },
   "YUASA": {
-    "charge_volt_start": 4.1,
-    "charge_volt_end": 4.1,
-    "charge_current_max": 10.0,
-    "dcharge_volt_min": 2.75,
-    "dcharge_current_max": 10,
-    "charge_volt_prot": 5,
-    "charge_current_prot": 50,
-    "charge_power_prot": 2000,
-    "slew_volt": 0.1,
-    "slew_current": 0.1,
-    "leadin_time": 1,
-    "charge_time": 5,
-    "dcharge_time": 5,
-    "num_cycles": 1,
-    "temperature": 27.0,
-    "test_name": "YUASA"
+    "test_type": "custom",
+    "parameters": {
+      "charge_volt_start": 4.1,
+      "charge_volt_end": 4.1,
+      "charge_current_max": 10.0,
+      "dcharge_volt_min": 2.75,
+      "dcharge_current_max": 10,
+      "charge_volt_prot": 5,
+      "charge_current_prot": 50,
+      "charge_power_prot": 2000,
+      "slew_volt": 0.1,
+      "slew_current": 0.1,
+      "leadin_time": 1,
+      "charge_time": 5,
+      "dcharge_time": 5,
+      "num_cycles": 1,
+      "temperature": 27.0,
+      "test_name": "YUASA"
+    }
   },
   "SAMSUNG": {
-    "charge_volt_start": 16.21,
-    "charge_volt_end": 16.4,
-    "charge_current_max": 5.0,
-    "dcharge_volt_min": 11.0,
-    "dcharge_current_max": 1,
-    "charge_volt_prot": 20,
-    "charge_current_prot": 10,
-    "charge_power_prot": 2000,
-    "slew_volt": 0.1,
-    "slew_current": 0.1,
-    "leadin_time": 1,
-    "charge_time": 5,
-    "dcharge_time": 5,
-    "num_cycles": 1,
-    "temperature": 27.0,
-    "test_name": "SAMSUNG"
+    "test_type": "efficiency_test",
+    "parameters": {
+      "charge_volt_start": 16.21,
+      "charge_volt_end": 16.4,
+      "charge_current_max": 5.0,
+      "dcharge_volt_min": 11.0,
+      "dcharge_current_max": 1,
+      "charge_volt_prot": 20,
+      "charge_current_prot": 10,
+      "charge_power_prot": 2000,
+      "slew_volt": 0.1,
+      "slew_current": 0.1,
+      "leadin_time": 1,
+      "charge_time": 5,
+      "dcharge_time": 5,
+      "num_cycles": 1,
+      "temperature": 27.0,
+      "test_name": "SAMSUNG"
+    }
   },
   "LG": {
-    "test_name": "LG"
+    "test_type": "custom",
+    "parameters": {
+      "test_name": "LG"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- redesign cell profile format to include `test_type` and settings block
- expose profile `test_type` from `load_config`
- run tests based on profile `test_type` and validate unsupported values

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689e0a7081388325a89987aee099789d