### PR TITLE
Add configurable charge/discharge modes for custom tests

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -341,8 +341,16 @@ class TestController:
         charge_time: int,
         dcharge_time: int,
         num_cycles: int,
+        charge_mode: str = "CC",
+        discharge_mode: str = "CC",
         multimeter_mode: str | None = None,
     ):
+        valid_modes = {"CC", "CV", "CP"}
+        if charge_mode not in valid_modes:
+            raise ValueError(f"Invalid charge_mode: {charge_mode}")
+        if discharge_mode not in valid_modes:
+            raise ValueError(f"Invalid discharge_mode: {discharge_mode}")
+
         TotstartTime = datetime.now()
         self.stop_event.clear()
         # Configure safety limits before running
@@ -386,20 +394,26 @@ class TestController:
                 try:
                     # Charging loop
                     self.startPSOutput()
-                    self.chargeCC(charge_current_max)
-                    self.setVoltage(charge_volt_start)
+                    if charge_mode == "CC":
+                        self.chargeCC(charge_current_max)
+                        self.setVoltage(charge_volt_start)
+                    elif charge_mode == "CV":
+                        self.chargeCV(charge_volt_end)
+                    elif charge_mode == "CP":
+                        self.chargeCP(charge_volt_end * charge_current_max)
                     print('Charging')
                     while datetime.now() < Cend_time and not self.stop_event.is_set():
                         time.sleep(self.timeInterval)
                         tmp = datetime.now() - ChargestartTime
-                        if leadin_time > 0:
-                            ratio = min(tmp.total_seconds() / float(leadin_time), 1.0)
-                        else:
-                            ratio = 1.0
-                        currentVolt = charge_volt_start + DeltaV * ratio
-                        if currentVolt > charge_volt_end:
-                            currentVolt = charge_volt_end
-                        self.setVoltage(currentVolt)
+                        if charge_mode == "CC":
+                            if leadin_time > 0:
+                                ratio = min(tmp.total_seconds() / float(leadin_time), 1.0)
+                            else:
+                                ratio = 1.0
+                            currentVolt = charge_volt_start + DeltaV * ratio
+                            if currentVolt > charge_volt_end:
+                                currentVolt = charge_volt_end
+                            self.setVoltage(currentVolt)
                         v_ps = self.getVoltagePSC()
                         v = self.getVoltageELC()
                         c = self.getCurrentPSC()
@@ -425,9 +439,12 @@ class TestController:
 
                     Dend_time = datetime.now() + Dduration
                     self.stopDischarge()
-                    self.setCCMmode()
-                    self.setCCcurrentL1(dcharge_current_max)
-                    self.startDischarge()
+                    if discharge_mode == "CC":
+                        self.dischargeCC(dcharge_current_max)
+                    elif discharge_mode == "CV":
+                        self.dischargeCV(dcharge_volt_min)
+                    elif discharge_mode == "CP":
+                        self.dischargeCP(dcharge_volt_min * dcharge_current_max)
 
                     DischargestartTime = datetime.now()
                     print('Discharging')

--- a/MAIN.py
+++ b/MAIN.py
@@ -61,6 +61,8 @@ class CustomTestSettings:
     charge_time: int = CHARGE_TIME
     dcharge_time: int = DCHARGE_TIME
     num_cycles: int = NUM_CYCLES
+    charge_mode: str = "CC"
+    discharge_mode: str = "CC"
     multimeter_mode: str | None = None
 
 
@@ -105,6 +107,12 @@ class TestTypes:
     def run_custom_test(self, settings: CustomTestSettings):
         """Start a custom test using the provided settings."""
         import threading
+        valid_modes = {"CC", "CV", "CP"}
+        if settings.charge_mode not in valid_modes:
+            raise ValueError(f"Invalid charge_mode: {settings.charge_mode}")
+        if settings.discharge_mode not in valid_modes:
+            raise ValueError(f"Invalid discharge_mode: {settings.discharge_mode}")
+
         self.testController.event.clear()
         self.custom_thread = threading.Thread(
             target=self.testController.custom_test,
@@ -125,6 +133,8 @@ class TestTypes:
                 settings.charge_time,
                 settings.dcharge_time,
                 settings.num_cycles,
+                settings.charge_mode,
+                settings.discharge_mode,
                 settings.multimeter_mode,
             ),
         )
@@ -161,6 +171,16 @@ def main():
     parser.add_argument("--leadin-time", type=int)
     parser.add_argument("--charge-time", type=int)
     parser.add_argument("--dcharge-time", type=int)
+    parser.add_argument(
+        "--charge-mode",
+        choices=["CC", "CV", "CP"],
+        help="charging mode: CC, CV or CP",
+    )
+    parser.add_argument(
+        "--discharge-mode",
+        choices=["CC", "CV", "CP"],
+        help="discharging mode: CC, CV or CP",
+    )
     parser.add_argument("--num-cycles", type=int)
     parser.add_argument("--actual-capacity-test", action="store_true",
                         help="run actual capacity test")

--- a/README.md
+++ b/README.md
@@ -49,9 +49,17 @@ pip install pyvisa pandas openpyxl matplotlib tabulate
 python MAIN.py
 ```
    If no hardware connection is detected the program aborts unless mock
-   drivers are enabled. Set the environment variable `USE_MOCK_DRIVERS=1`
-   to force the built‑in mock drivers for development without hardware.
-   Use the `-d` flag to print detailed progress messages during a test.
+drivers are enabled. Set the environment variable `USE_MOCK_DRIVERS=1`
+to force the built‑in mock drivers for development without hardware.
+Use the `-d` flag to print detailed progress messages during a test.
+
+Charging and discharging default to constant current (`CC`). Select
+constant voltage (`CV`) or constant power (`CP`) with the
+`--charge-mode` and `--discharge-mode` options:
+
+```bash
+python MAIN.py --charge-mode CV --discharge-mode CP
+```
 
 ### Instrument resource names
 


### PR DESCRIPTION
## Summary
- allow selecting charge_mode and discharge_mode (CC/CV/CP) from CLI or config
- validate modes and pass through to custom_test
- branch in TestController.custom_test to call appropriate charge/discharge helpers
- document charge and discharge mode flags in README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689e0ea635788325a2396cce9ed6c6ae