### PR TITLE
Add configurable rest period to custom tests

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -340,6 +340,7 @@ class TestController:
         leadin_time: int,
         charge_time: int,
         dcharge_time: int,
+        rest_time: int,
         num_cycles: int,
         multimeter_mode: str | None = None,
     ):
@@ -422,6 +423,8 @@ class TestController:
                             assert mm is not None
                             dataStorage.addMMTemperature(mm)
                     self.stopPSOutput()
+                    if rest_time > 0:
+                        time.sleep(rest_time)
 
                     Dend_time = datetime.now() + Dduration
                     self.stopDischarge()
@@ -458,6 +461,8 @@ class TestController:
                             print(f"below {dcharge_volt_min} volts")
                             break
                     self.stopDischarge()
+                    if rest_time > 0:
+                        time.sleep(rest_time)
                 except KeyboardInterrupt:
                     print("Keyboard interrupt - aborting test")
                     self.abort()

--- a/MAIN.py
+++ b/MAIN.py
@@ -32,6 +32,7 @@ LEADIN_TIME: int = 1    # s
 
 CHARGE_TIME: int = 5    # s
 DCHARGE_TIME: int = 5   # s
+REST_TIME: int = 0      # s
 
 # Cycling
 NUM_CYCLES: int = 1   # n
@@ -60,6 +61,7 @@ class CustomTestSettings:
     leadin_time: int = LEADIN_TIME
     charge_time: int = CHARGE_TIME
     dcharge_time: int = DCHARGE_TIME
+    rest_time: int = REST_TIME
     num_cycles: int = NUM_CYCLES
     multimeter_mode: str | None = None
 
@@ -124,6 +126,7 @@ class TestTypes:
                 settings.leadin_time,
                 settings.charge_time,
                 settings.dcharge_time,
+                settings.rest_time,
                 settings.num_cycles,
                 settings.multimeter_mode,
             ),
@@ -161,6 +164,7 @@ def main():
     parser.add_argument("--leadin-time", type=int)
     parser.add_argument("--charge-time", type=int)
     parser.add_argument("--dcharge-time", type=int)
+    parser.add_argument("--rest-time", type=int)
     parser.add_argument("--num-cycles", type=int)
     parser.add_argument("--actual-capacity-test", action="store_true",
                         help="run actual capacity test")

--- a/README.md
+++ b/README.md
@@ -197,10 +197,12 @@ The top of `MAIN.py` contains constants used to configure a test run:
 | `LEADIN_TIME` | `1` | s |
 | `CHARGE_TIME` | `5` | s |
 | `DCHARGE_TIME` | `5` | s |
+| `REST_TIME` | `0` | s |
 | `NUM_CYCLES` | `1` | &ndash; |
 
 `LEADIN_TIME` controls how long the power supply ramps from
 `CHARGE_VOLT_START` to `CHARGE_VOLT_END` at the beginning of each charge cycle.
+`REST_TIME` defines a pause inserted after each charge or discharge phase.
 
 Refer to the device programming manuals for the meaning of each setting.
 
@@ -227,6 +229,7 @@ common flags accepted by `MAIN.py` are listed below. Run
 | `--leadin-time` | Time in seconds used to ramp the supply from the starting to the ending charge voltage |
 | `--charge-time` | Allowed charging time |
 | `--dcharge-time` | Allowed discharging time |
+| `--rest-time` | Rest period in seconds between charge and discharge |
 | `--num-cycles` | Number of charge/discharge cycles |
 | `--multimeter-mode` | Log measurement using the multimeter (`voltage` or `tcouple`) |
 | `-d`, `--debug` | Print detailed progress information |


### PR DESCRIPTION
## Summary
- allow custom tests to define a `rest_time` between charge and discharge phases
- propagate `rest_time` through `TestTypes` to `custom_test`
- document the new `--rest-time` option

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689e0eb0150c83258aa69484a2de2678