### PR TITLE
Add configurable sampling interval for custom tests

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -323,7 +323,7 @@ class TestController:
     # Test protocal for testing the capacity of a battery
 
 # This function is called from the TestTypes class to run a custom test
-    def custom_test(
+    def _custom_test_impl(
         self,
         test_name: str,
         temperature: float,
@@ -483,6 +483,52 @@ class TestController:
 
         # Set the event to indicate that testing is finished
         self.event.set()
+
+    def custom_test(
+        self,
+        test_name: str,
+        temperature: float,
+        charge_volt_prot: int,
+        charge_current_prot: int,
+        charge_power_prot: int,
+        charge_volt_start: float,
+        charge_volt_end: float,
+        charge_current_max: float,
+        dcharge_volt_min: float,
+        dcharge_current_max: float,
+        slew_volt: float,
+        slew_current: float,
+        leadin_time: int,
+        charge_time: int,
+        dcharge_time: int,
+        num_cycles: int,
+        sample_interval: float,
+        multimeter_mode: str | None = None,
+    ):
+        prev_interval = self.timeInterval
+        self.timeInterval = sample_interval
+        try:
+            self._custom_test_impl(
+                test_name,
+                temperature,
+                charge_volt_prot,
+                charge_current_prot,
+                charge_power_prot,
+                charge_volt_start,
+                charge_volt_end,
+                charge_current_max,
+                dcharge_volt_min,
+                dcharge_current_max,
+                slew_volt,
+                slew_current,
+                leadin_time,
+                charge_time,
+                dcharge_time,
+                num_cycles,
+                multimeter_mode,
+            )
+        finally:
+            self.timeInterval = prev_interval
 
     def efficiency_test(
         self,

--- a/MAIN.py
+++ b/MAIN.py
@@ -61,6 +61,7 @@ class CustomTestSettings:
     charge_time: int = CHARGE_TIME
     dcharge_time: int = DCHARGE_TIME
     num_cycles: int = NUM_CYCLES
+    sample_interval: float = TestController.timeInterval
     multimeter_mode: str | None = None
 
 
@@ -125,6 +126,7 @@ class TestTypes:
                 settings.charge_time,
                 settings.dcharge_time,
                 settings.num_cycles,
+                settings.sample_interval,
                 settings.multimeter_mode,
             ),
         )
@@ -162,6 +164,7 @@ def main():
     parser.add_argument("--charge-time", type=int)
     parser.add_argument("--dcharge-time", type=int)
     parser.add_argument("--num-cycles", type=int)
+    parser.add_argument("--sample-interval", type=float)
     parser.add_argument("--actual-capacity-test", action="store_true",
                         help="run actual capacity test")
     parser.add_argument("--capacity-charge-current", type=float,

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ common flags accepted by `MAIN.py` are listed below. Run
 | `--charge-time` | Allowed charging time |
 | `--dcharge-time` | Allowed discharging time |
 | `--num-cycles` | Number of charge/discharge cycles |
+| `--sample-interval` | Time between measurements in seconds |
 | `--multimeter-mode` | Log measurement using the multimeter (`voltage` or `tcouple`) |
 | `-d`, `--debug` | Print detailed progress information |
 


### PR DESCRIPTION
## Summary
- allow custom tests to specify a sampling interval via `--sample-interval`
- `TestController.custom_test` now applies the provided interval only for the test duration
- document the new option in README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689e0eb382bc832586aa8937b30782a4