### PR TITLE
Add profile listing option and default profile file

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -158,7 +158,12 @@ class TestTypes:
 def main():
     parser = argparse.ArgumentParser(description="Run custom test")
     parser.add_argument(
-        "--config-file", default="profiles.json", help="JSON file with cell settings"
+        "--config-file", help="JSON file with cell settings (defaults to profiles.json)"
+    )
+    parser.add_argument(
+        "--list-profiles",
+        action="store_true",
+        help="List available profiles and exit",
     )
     parser.add_argument("--profile", help="cell profile name in config file")
     parser.add_argument("--ps-resource", help="VISA resource name for power supply")
@@ -249,13 +254,27 @@ def main():
 
     args = parser.parse_args()
 
+    if args.list_profiles:
+        config_path = args.config_file or "profiles.json"
+        try:
+            data = json.loads(Path(config_path).read_text())
+        except (FileNotFoundError, json.JSONDecodeError) as exc:
+            print(f"Error reading {config_path}: {exc}")
+            return
+        for name in data:
+            if name != "capacity_defaults":
+                print(name)
+        return
 
     profile = args.profile or args.test_name or TEST_NAME
     config = {}
     capacity_defaults = {}
     test_type = None
-    if args.config_file:
-        config, capacity_defaults, test_type = load_config(args.config_file, profile)
+    config_file = args.config_file
+    if args.profile and not config_file:
+        config_file = "profiles.json"
+    if config_file:
+        config, capacity_defaults, test_type = load_config(config_file, profile)
 
     ps_resource = (
         args.ps_resource
@@ -378,7 +397,7 @@ def main():
             finish_current,
         )
         print(f"Measured capacity: {capacity:.3f} Ah")
-    elif args.config_file and test_type:
+    elif config_file and test_type:
         tc = TestController(multimeter_mode, args.debug, ps_resource, el_resource, mm_resource)
         if test_type == "actual_capacity_test":
             tc.actual_capacity_test(

--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ python MAIN.py
    If no hardware connection is detected the program aborts unless mock
 drivers are enabled. Set the environment variable `USE_MOCK_DRIVERS=1`
 to force the built‑in mock drivers for development without hardware.
-Use the `-d` flag to print detailed progress messages during a test.
+ Use the `-d` flag to print detailed progress messages during a test.
+
+To display the profiles defined in a configuration file run:
+
+```bash
+python MAIN.py --list-profiles [--config-file other.json]
+```
+
+Without `--config-file` the command looks for `profiles.json`.
 
 Charging and discharging default to constant current (`CC`). Select
 constant voltage (`CV`) or constant power (`CP`) with the
@@ -165,7 +173,13 @@ Run the profile without additional flags and `MAIN.py` selects the
 appropriate test based on `test_type`:
 
 ```bash
-python MAIN.py --config-file profiles.json --profile YUASA
+python MAIN.py --profile YUASA
+```
+
+To use a different configuration file:
+
+```bash
+python MAIN.py --config-file custom.json --profile YUASA
 ```
 
 Command-line options still override the values loaded from the profile.


### PR DESCRIPTION
## Summary
- add `--list-profiles` to MAIN.py for listing available profiles
- load `profiles.json` automatically when `--profile` is used and allow optional config files
- document new options and usage in README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689e16edeef0832583a0a9bf770abf32