### PR TITLE
Add rest and mode options to custom test

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -523,7 +523,10 @@ class TestController:
         leadin_time: int,
         charge_time: int,
         dcharge_time: int,
+        rest_time: int,
         num_cycles: int,
+        charge_mode: str,
+        discharge_mode: str,
         sample_interval: float,
         multimeter_mode: str | None = None,
     ):
@@ -546,7 +549,10 @@ class TestController:
                 leadin_time,
                 charge_time,
                 dcharge_time,
+                rest_time,
                 num_cycles,
+                charge_mode,
+                discharge_mode,
                 multimeter_mode,
             )
         finally:


### PR DESCRIPTION
## Summary
- allow `custom_test` to accept rest period and charge/discharge modes
- forward new parameters to `_custom_test_impl`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689f0d0158608325a57aa94c6d770844