### PR TITLE
refactor: centralize sample interval

### DIFF
--- a/AlIonBatteryTestSoftware.py
+++ b/AlIonBatteryTestSoftware.py
@@ -8,7 +8,7 @@ import os
 from AlIonTestSoftwareDeviceDrivers import PowerSupplyController, ElectronicLoadController, MultimeterController
 from AlIonTestSoftwareDeviceDriversMock import PowerSupplyControllerMock, ElectronicLoadControllerMock, MultimeterControllerMock
 from AlIonTestSoftwareDataManagement import DataStorage
-from defaults import DEFAULT_LIMITS
+from defaults import DEFAULT_LIMITS, DEFAULT_SAMPLE_INTERVAL
 
 import struct
 import traceback
@@ -24,11 +24,9 @@ except Exception:  # pyvisa may not be installed when using mock drivers
 # Class used to control test procedures
 class TestController:
     """Coordinate power supply, load and measurement devices for tests."""
-    # Indicates the number of seconds between each measurement
-    timeInterval = 0.2
-    # Variable for keeping track of the open circuit voltage of a full battery
-    # Variable for keeping track of the open circuit voltage of an empty battery
-    # Variable for keeping track of the C-rate of the battery
+    # Default number of seconds between each measurement. Instances store the
+    # current interval in ``self.timeInterval`` which defaults to
+    # ``DEFAULT_SAMPLE_INTERVAL`` but can be overridden.
 
     # Initiating function
     def __init__(
@@ -39,6 +37,7 @@ class TestController:
         el_resource: str | None = None,
         mm_resource: str | None = None,
         use_mock: bool | None = None,
+        sample_interval: float = DEFAULT_SAMPLE_INTERVAL,
     ) -> None:
         self.multimeter_mode = multimeter_mode
         self.debug = debug
@@ -95,6 +94,8 @@ class TestController:
         self.event = threading.Event()
         # Event used to gracefully abort a running test
         self.stop_event = threading.Event()
+        # Sampling interval between measurements
+        self.timeInterval = sample_interval
 
     def _debug(self, message: str, mm_value: float | None = None) -> None:
         """Print debug message when debug mode is enabled.

--- a/AlIonTestSoftwareDataManagement.py
+++ b/AlIonTestSoftwareDataManagement.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pandas import errors as pd_errors
 import math
 import statistics
+from defaults import DEFAULT_SAMPLE_INTERVAL
 
 
 class DataStorage:
@@ -66,7 +67,7 @@ class DataStorage:
         c_rate: float,
         cycleNr: int,
         temperature: float,
-        timeInterval: float,
+        timeInterval: float = DEFAULT_SAMPLE_INTERVAL,
         chargeTime=0,
         export_xlsx: bool = False,
         verbose: bool = False,
@@ -170,7 +171,7 @@ class DataStorage:
         df = pd.DataFrame(data, columns=head)
         df.to_csv(filePath + ".csv", index=False, float_format="%.4f")
 
-    def exportXLSXFile(self, filePath, chargeTime, timeInterval):
+    def exportXLSXFile(self, filePath, chargeTime, timeInterval=DEFAULT_SAMPLE_INTERVAL):
         """Create an Excel workbook with optional graphs."""
         # Read in the CSV file that was just created
         csvDataframe = pd.read_csv(filePath + ".csv")

--- a/MAIN.py
+++ b/MAIN.py
@@ -6,7 +6,11 @@ import json
 import os
 from pathlib import Path
 from AlIonBatteryTestSoftware import TestController
-from defaults import DEFAULT_LIMITS, DEFAULT_TEST_PARAMS
+from defaults import (
+    DEFAULT_LIMITS,
+    DEFAULT_TEST_PARAMS,
+    DEFAULT_SAMPLE_INTERVAL,
+)
 
 # Charge/discharge voltage and current limits
 CHARGE_VOLT_START: float = DEFAULT_TEST_PARAMS["CHARGE_VOLT_START"]
@@ -65,7 +69,7 @@ class CustomTestSettings:
     num_cycles: int = NUM_CYCLES
     charge_mode: str = "CC"
     discharge_mode: str = "CC"
-    sample_interval: float = TestController.timeInterval
+    sample_interval: float = DEFAULT_SAMPLE_INTERVAL
     multimeter_mode: str | None = None
 
 

--- a/defaults.py
+++ b/defaults.py
@@ -61,5 +61,9 @@ DEFAULT_TEST_PARAMS: TestDefaults = {
 }
 
 
-__all__ = ["DEFAULT_LIMITS", "DEFAULT_TEST_PARAMS"]
+# Default time interval between each measurement in seconds
+DEFAULT_SAMPLE_INTERVAL: float = 0.2
+
+
+__all__ = ["DEFAULT_LIMITS", "DEFAULT_TEST_PARAMS", "DEFAULT_SAMPLE_INTERVAL"]
 


### PR DESCRIPTION
## Summary
- provide DEFAULT_SAMPLE_INTERVAL in defaults module
- use default interval via constructor in TestController
- consume default interval in main CLI and data storage utilities

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689f1e14b9888325bbedbe346e364dc4