### PR TITLE
Clarify CLI test type flag priority over profile setting

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -1,4 +1,8 @@
-"""Command line interface for running custom battery tests."""
+"""Command line interface for running battery tests.
+
+Command-line test type flags (e.g., ``--efficiency-test``) take priority
+over the ``test_type`` defined in a profile.
+"""
 
 from dataclasses import dataclass
 import argparse
@@ -218,8 +222,11 @@ def main():
         help="discharging mode: CC, CV or CP",
     )
     parser.add_argument("--num-cycles", type=int)
-    parser.add_argument("--actual-capacity-test", action="store_true",
-                        help="run actual capacity test")
+    parser.add_argument(
+        "--actual-capacity-test",
+        action="store_true",
+        help="run actual capacity test (overrides profile test_type)",
+    )
     parser.add_argument("--capacity-charge-current", type=float,
                         help="charge current for capacity test in amperes")
     parser.add_argument("--capacity-discharge-current", type=float,
@@ -232,16 +239,28 @@ def main():
                         help="minimum discharge voltage for capacity test")
     parser.add_argument("--capacity-finish-current", type=float,
                         help="current threshold to end charging during capacity test")
-    parser.add_argument("--efficiency-test", action="store_true",
-                        help="run efficiency test")
-    parser.add_argument("--rate-characteristic-test", action="store_true",
-                        help="run rate characteristic test")
-    parser.add_argument("--ocv-curve-test", action="store_true",
-                        help="run OCV curve test")
+    parser.add_argument(
+        "--efficiency-test",
+        action="store_true",
+        help="run efficiency test (overrides profile test_type)",
+    )
+    parser.add_argument(
+        "--rate-characteristic-test",
+        action="store_true",
+        help="run rate characteristic test (overrides profile test_type)",
+    )
+    parser.add_argument(
+        "--ocv-curve-test",
+        action="store_true",
+        help="run OCV curve test (overrides profile test_type)",
+    )
     parser.add_argument(
         "--internal-resistance-test",
         action="store_true",
-        help="run internal resistance test (no capacity measurement)",
+        help=(
+            "run internal resistance test (no capacity measurement) "
+            "and override profile test_type"
+        ),
     )
     parser.add_argument("--rates", default="1.0,0.5,0.2",
                         help="comma separated discharge rates in A")
@@ -334,6 +353,7 @@ def main():
         "ocv_curve_test": args.ocv_curve_test,
         "internal_resistance_test": args.internal_resistance_test,
     }
+    # Command-line flags override the ``test_type`` loaded from a profile
     resolved_test_type = next((t for t, flag in cli_flags.items() if flag), None)
     if resolved_test_type is None:
         resolved_test_type = test_type or "custom"

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ Common commands:
   ```
 
   When the profile supplies a `test_type` and all required parameters, tests
-  can be launched without any additional command‑line options. The
-  `required_keys` section in `profiles.json` lists the parameters that must
-  be present for each test type; missing entries trigger an error when a
-  profile is loaded. Examples:
+  can be launched without any additional command‑line options. Passing a
+  command-line test type flag (for example, `--efficiency-test`) overrides the
+  profile's `test_type`. The `required_keys` section in `profiles.json` lists
+  the parameters that must be present for each test type; missing entries
+  trigger an error when a profile is loaded. Examples:
 
   ```bash
   # Custom cycle test
@@ -215,7 +216,8 @@ appropriate test based on `test_type`:
 python MAIN.py --profile YUASA
 ```
 
-Command-line options still override the values loaded from the profile.
+Command-line options still override the values loaded from the profile,
+including any test type flags.
 
 The helper `build_test_config.py` prompts for a test name and `test_type`
 and then gathers the relevant parameters before adding the profile to


### PR DESCRIPTION
## Summary
- Document that command-line test type flags override a profile's `test_type`
- Note flag precedence in `MAIN.py` argument parsing
- Mention test type flag priority in README usage instructions

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689f263eb6708325996364c4b9567a14