### PR TITLE
Annotate builder function return types

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -10,6 +10,7 @@ import json
 import os
 from pathlib import Path
 from pprint import pprint
+from typing import Any
 from defaults import (
     DEFAULT_LIMITS,
     DEFAULT_TEST_PARAMS,
@@ -399,7 +400,7 @@ def main():
             val = default
         return val
 
-    def build_actual_capacity_params():
+    def build_actual_capacity_params() -> dict[str, Any]:
         return {
             "charge_current_1c": resolve_param(
                 "capacity_charge_current", "capacity_charge_current", 1.0
@@ -420,7 +421,7 @@ def main():
             ),
         }
 
-    def build_efficiency_params():
+    def build_efficiency_params() -> dict[str, Any]:
         return {
             "charge_current": resolve_param(
                 "charge_current_max", "charge_current_max", CHARGE_CURRENT_MAX
@@ -437,7 +438,7 @@ def main():
             "temperature": resolve_param("temperature", "temperature", TEMPERATURE),
         }
 
-    def build_rate_params():
+    def build_rate_params() -> dict[str, Any]:
         rates_val = resolve_param("rates", "rates", "1.0,0.5,0.2")
         if isinstance(rates_val, str):
             rates = [float(r) for r in rates_val.split(",") if r]
@@ -457,7 +458,7 @@ def main():
             "temperature": resolve_param("temperature", "temperature", TEMPERATURE),
         }
 
-    def build_ocv_params():
+    def build_ocv_params() -> dict[str, Any]:
         return {
             "step_current": resolve_param("step_current", "step_current", 1.0),
             "steps": resolve_param("steps", "steps", 10),
@@ -465,7 +466,7 @@ def main():
             "temperature": resolve_param("temperature", "temperature", TEMPERATURE),
         }
 
-    def build_ir_params():
+    def build_ir_params() -> dict[str, Any]:
         return {
             "pulse_current": resolve_param("pulse_current", "pulse_current", 1.0),
             "pulse_duration": resolve_param(
@@ -474,7 +475,7 @@ def main():
             "temperature": resolve_param("temperature", "temperature", TEMPERATURE),
         }
 
-    def build_custom_params():
+    def build_custom_params() -> dict[str, Any]:
         # Apply the same resolution order as ``resolve_param`` so that the CLI
         # can override values from the profile.  "config" is consulted only
         # after ``params_section`` to allow the profile's "parameters" section

--- a/build_test_config.py
+++ b/build_test_config.py
@@ -164,7 +164,7 @@ def _prompt_multimeter_mode() -> str:
         print(f"Enter one of: {choices}.")
 
 
-def build_custom_settings(test_name: str) -> dict:
+def build_custom_settings(test_name: str) -> dict[str, Any]:
     """Collect custom test settings from the user with range validation."""
     custom = {"test_name": test_name}
     for field, default in CUSTOM_DEFAULTS.items():
@@ -179,7 +179,7 @@ def build_custom_settings(test_name: str) -> dict:
     return custom
 
 
-def build_capacity_settings(test_name: str) -> dict:
+def build_capacity_settings(test_name: str) -> dict[str, Any]:
     """Collect parameters for ``actual_capacity_test``."""
     cap = {"test_name": test_name}
     for field, default in CAPACITY_DEFAULTS.items():
@@ -189,7 +189,7 @@ def build_capacity_settings(test_name: str) -> dict:
     return cap
 
 
-def build_efficiency_settings(test_name: str) -> dict:
+def build_efficiency_settings(test_name: str) -> dict[str, Any]:
     """Collect parameters for ``efficiency_test``."""
     eff = {"test_name": test_name}
     for field, default in EFFICIENCY_DEFAULTS.items():
@@ -199,7 +199,7 @@ def build_efficiency_settings(test_name: str) -> dict:
     return eff
 
 
-def build_rate_settings(test_name: str) -> dict:
+def build_rate_settings(test_name: str) -> dict[str, Any]:
     """Collect parameters for ``rate_characteristic_test``."""
     rate = {"test_name": test_name}
     default_rates = ",".join(str(r) for r in RATE_DEFAULTS["discharge_currents"])
@@ -218,7 +218,7 @@ def build_rate_settings(test_name: str) -> dict:
     return rate
 
 
-def build_ocv_settings(test_name: str) -> dict:
+def build_ocv_settings(test_name: str) -> dict[str, Any]:
     """Collect parameters for ``ocv_curve_test``."""
     ocv = {"test_name": test_name}
     ocv["step_current"] = _prompt_number(
@@ -253,7 +253,7 @@ def build_ocv_settings(test_name: str) -> dict:
     return ocv
 
 
-def build_resistance_settings(test_name: str) -> dict:
+def build_resistance_settings(test_name: str) -> dict[str, Any]:
     """Collect parameters for ``internal_resistance_test``."""
     res = {"test_name": test_name}
     for field, default in RESISTANCE_DEFAULTS.items():


### PR DESCRIPTION
## Summary
- type annotate builder functions to return `dict[str, Any]`
- import `Any` in main module for typed builders

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689f29c1fae08325885abe6530a6389d