### PR TITLE
Default multimeter to tcouple

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -74,7 +74,7 @@ class CustomTestSettings:
     charge_mode: str = "CC"
     discharge_mode: str = "CC"
     sample_interval: float = DEFAULT_SAMPLE_INTERVAL
-    multimeter_mode: str | None = None
+    multimeter_mode: str = "tcouple"
 
 
 
@@ -291,7 +291,7 @@ def main():
     parser.add_argument(
         "--multimeter-mode",
         choices=["voltage", "tcouple"],
-        help="log measurement with multimeter (voltage or thermocouple)"
+        help="log measurement with multimeter (voltage or thermocouple, default: tcouple)"
     )
     parser.add_argument(
         "-d",
@@ -357,14 +357,14 @@ def main():
         or config.get("mm_resource")
     )
 
-    def resolve_multimeter_mode() -> str | None:
+    def resolve_multimeter_mode() -> str:
         """Return validated multimeter mode from CLI, params or config."""
         mode = config.get("multimeter_mode")
         if mode is None:
             mode = params_section.get("multimeter_mode")
         if mode is None:
-            mode = args.multimeter_mode
-        if mode not in {None, "voltage", "tcouple"}:
+            mode = args.multimeter_mode or "tcouple"
+        if mode not in {"voltage", "tcouple"}:
             raise ValueError(f"Invalid multimeter_mode: {mode}")
         return mode
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ common flags accepted by `MAIN.py` are listed below. Run
 | `--rest-time` | Rest period in seconds between charge and discharge |
 | `--num-cycles` | Number of charge/discharge cycles |
 | `--sample-interval` | Time between measurements in seconds |
-| `--multimeter-mode` | Log measurement using the multimeter (`voltage` or `tcouple`) |
+| `--multimeter-mode` | Log measurement using the multimeter (`voltage` or `tcouple`, default `tcouple`) |
 | `-d`, `--debug` | Print detailed progress information |
 | `--dry-run` | Display resolved parameters and exit without running a test |
 


### PR DESCRIPTION
## Summary
- default `CustomTestSettings.multimeter_mode` to `'tcouple'`
- choose `'tcouple'` when no multimeter mode is provided
- document the thermocouple default in the CLI help and README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689f29de43508325aaa70e548bc798aa