### PR TITLE
Reorder multimeter mode resolution

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -354,12 +354,21 @@ def main():
     )
 
     def resolve_multimeter_mode() -> str:
-        """Return validated multimeter mode from CLI, params or config."""
-        mode = config.get("multimeter_mode")
+        """Return validated multimeter mode.
+
+        Resolution order:
+        1. Command line argument
+        2. Profile's "parameters" section
+        3. Top level of the profile
+        4. Default "tcouple"
+        """
+        mode = args.multimeter_mode
         if mode is None:
             mode = params_section.get("multimeter_mode")
         if mode is None:
-            mode = args.multimeter_mode or "tcouple"
+            mode = config.get("multimeter_mode")
+        if mode is None:
+            mode = "tcouple"
         if mode not in {"voltage", "tcouple"}:
             raise ValueError(f"Invalid multimeter_mode: {mode}")
         return mode

--- a/README.md
+++ b/README.md
@@ -231,7 +231,10 @@ including any test type flags.
 The helper `build_test_config.py` prompts for a test name and `test_type`
 and then gathers the relevant parameters before adding the profile to
 `profiles.json`.
-It also asks for a multimeter mode (`voltage` or `tcouple`) and defaults to `tcouple`.
+It also asks for a multimeter mode (`voltage` or `tcouple`) and defaults to
+`tcouple`. At runtime the mode is resolved with command-line options taking
+priority, followed by the profile's `parameters` section, the top-level profile
+configuration and finally the built-in default `tcouple`.
 
 This charges the cell at 1C up to the voltage specified by
 `--capacity-charge-voltage` (default taken from `--charge-volt-end`),


### PR DESCRIPTION
## Summary
- Reorder multimeter mode resolution to prioritize CLI, then profile parameters, config, and default
- Document the new resolution order in code and README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689f2eb730bc832580226b0c274b57fa