### PR TITLE
Support capacity defaults for capacity test parameters

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -259,9 +259,12 @@ def main():
     config_file = args.config_file
     if args.profile and not config_file:
         config_file = "profiles.json"
+    capacity_defaults: dict[str, Any] = {}
     if config_file:
         try:
-            config, _, test_type, required_keys = load_config(config_file, profile)
+            config, capacity_defaults, test_type, required_keys = load_config(
+                config_file, profile
+            )
         except KeyError as exc:
             print(exc)
             return
@@ -297,13 +300,16 @@ def main():
         1. Command line argument
         2. Profile's "parameters" section
         3. Top level of the profile
-        4. Default "tcouple"
+        4. ``capacity_defaults`` mapping
+        5. Default "tcouple"
         """
         mode = args.multimeter_mode
         if mode is None:
             mode = params_section.get("multimeter_mode")
         if mode is None:
             mode = config.get("multimeter_mode")
+        if mode is None:
+            mode = capacity_defaults.get("multimeter_mode")
         if mode is None:
             mode = "tcouple"
         if mode not in {"voltage", "tcouple"}:
@@ -346,27 +352,43 @@ def main():
     def build_actual_capacity_params() -> dict[str, Any]:
         return {
             "charge_current_1c": resolve_param(
-                "capacity_charge_current", "capacity_charge_current", 1.0
+                "capacity_charge_current",
+                "capacity_charge_current",
+                capacity_defaults.get("charge_current", 1.0),
             ),
             "discharge_current_1c": resolve_param(
-                "capacity_discharge_current", "capacity_discharge_current", 1.0
+                "capacity_discharge_current",
+                "capacity_discharge_current",
+                capacity_defaults.get("discharge_current", 1.0),
             ),
-            "rest_time": resolve_param("capacity_rest_time", "capacity_rest_time", 3600.0),
+            "rest_time": resolve_param(
+                "capacity_rest_time",
+                "capacity_rest_time",
+                capacity_defaults.get("rest_time", 3600.0),
+            ),
             "charge_voltage": resolve_param(
                 "capacity_charge_voltage",
                 "capacity_charge_voltage",
-                DEFAULT_LIMITS["CHARGE_VOLT_END"],
+                capacity_defaults.get("charge_voltage", DEFAULT_LIMITS["CHARGE_VOLT_END"]),
             ),
             "min_voltage": resolve_param(
                 "capacity_min_voltage",
                 "capacity_min_voltage",
-                DEFAULT_TEST_PARAMS["DCHARGE_VOLT_MIN"],
+                capacity_defaults.get(
+                    "min_voltage", DEFAULT_TEST_PARAMS["DCHARGE_VOLT_MIN"]
+                ),
             ),
             "temperature": resolve_param(
-                "temperature", "temperature", DEFAULT_TEST_PARAMS["TEMPERATURE"]
+                "temperature",
+                "temperature",
+                capacity_defaults.get(
+                    "temperature", DEFAULT_TEST_PARAMS["TEMPERATURE"]
+                ),
             ),
             "finish_current": resolve_param(
-                "capacity_finish_current", "capacity_finish_current", 1.5
+                "capacity_finish_current",
+                "capacity_finish_current",
+                capacity_defaults.get("finish_current", 1.5),
             ),
         }
 

--- a/README.md
+++ b/README.md
@@ -143,14 +143,14 @@ python MAIN.py --actual-capacity-test \
   [--capacity-finish-current 1.5]
 ```
 ``--capacity-charge-voltage`` defaults to the value of ``--charge-volt-end``
-(or ``4.1``&nbsp;V). ``--capacity-rest-time`` and ``--capacity-min-voltage``
-fall back to the values in the ``capacity_defaults`` section of the JSON
-file passed with ``--config-file`` or, if that section is absent, to one
-hour and ``2.75``&nbsp;V respectively.
+(or ``4.1``&nbsp;V). When omitted, capacity‑specific options fall back to values
+in the ``capacity_defaults`` section of the JSON file passed with
+``--config-file`` or, if that section is absent, to the built‑in defaults
+(for example one hour rest time and ``2.75``&nbsp;V minimum voltage).
 
 The configuration file may define ``rest_time``, ``charge_voltage``,
 ``min_voltage``, ``charge_current``, ``discharge_current``,
-``finish_current`` and ``multimeter_mode`` keys inside
+``finish_current``, ``temperature`` and ``multimeter_mode`` keys inside
 ``capacity_defaults``. These values override the built‑in defaults in
 ``MAIN.py`` but any command-line options still take precedence.
 

--- a/profiles.json
+++ b/profiles.json
@@ -36,6 +36,16 @@
     ],
     "custom": []
   },
+  "capacity_defaults": {
+    "rest_time": 3600.0,
+    "charge_voltage": 4.1,
+    "min_voltage": 2.75,
+    "charge_current": 1.0,
+    "discharge_current": 1.0,
+    "finish_current": 1.5,
+    "temperature": 23.4,
+    "multimeter_mode": "tcouple"
+  },
   "YUASA_ACT1": {
     "test_type": "actual_capacity_test",
     "parameters": {


### PR DESCRIPTION
## Summary
- load optional `capacity_defaults` from config
- use `capacity_defaults` when resolving actual capacity test parameters and multimeter mode
- document capacity defaults and include example values in `profiles.json`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689f306511b48325931cc6362bfc75d4