### PR TITLE
Separate profile and test name handling

### DIFF
--- a/MAIN.py
+++ b/MAIN.py
@@ -252,15 +252,15 @@ def main():
                 print(name)
         return
 
-    profile = args.profile or args.test_name or DEFAULT_TEST_PARAMS["TEST_NAME"]
+    profile = args.profile
     config: dict = {}
     test_type = None
     required_keys: dict = {}
-    config_file = args.config_file
-    if args.profile and not config_file:
-        config_file = "profiles.json"
     capacity_defaults: dict[str, Any] = {}
-    if config_file:
+    config_file = args.config_file
+    if profile:
+        if not config_file:
+            config_file = "profiles.json"
         try:
             config, capacity_defaults, test_type, required_keys = load_config(
                 config_file, profile
@@ -477,7 +477,10 @@ def main():
         for field in CustomTestSettings.__annotations__.keys():
             if field == "multimeter_mode":
                 continue
-            val = getattr(args, field, None)
+            if field == "test_name" and profile:
+                val = None
+            else:
+                val = getattr(args, field, None)
             if val is None:
                 val = params_section.get(field)
             if val is None:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Common commands:
   The profile name must exist in the configuration file; otherwise an error
   is reported.
 
+  The `--test-name` option does not select profiles. It only sets the
+  name used in output files when running without `--profile`.
+
   When the profile supplies a `test_type` and all required parameters, tests
   can be launched without any additional command‑line options. Passing a
   command-line test type flag (for example, `--efficiency-test`) overrides the
@@ -284,7 +287,7 @@ common flags accepted by `MAIN.py` are listed below. Run
 
 | Option | Description |
 | --- | --- |
-| `--test-name` | Name used for log and output files |
+| `--test-name` | Name used for log and output files when no profile is selected |
 | `--temperature` | Ambient temperature in °C |
 | `--charge-volt-prot` | Overvoltage protection limit |
 | `--charge-current-prot` | Overcurrent protection limit |


### PR DESCRIPTION
## Summary
- Use `--profile` exclusively for selecting configuration profiles
- Apply `--test-name` only when running without a profile
- Document distinction between profile selection and test naming

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689f31b7260c832583adfca60d7d710a