### PR TITLE
Add tests for required key validation and multimeter mode override

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import importlib
 import pathlib
+import pytest
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -37,3 +38,38 @@ def test_num_cycles_cli_overrides_profile(monkeypatch):
     tc_cls.assert_called_once()
     tc_instance.custom_test.assert_called_once()
     assert tc_instance.custom_test.call_args.kwargs["num_cycles"] == 1
+
+
+def test_validate_required_keys_missing_parameters():
+    """Missing required keys trigger a KeyError."""
+    profile = {"parameters": {"temperature": 25.0}}
+    required = {"custom": ["temperature", "dcharge_current_max"]}
+    with pytest.raises(KeyError) as excinfo:
+        MAIN.validate_required_keys(profile, required, "custom")
+    assert "dcharge_current_max" in str(excinfo.value)
+
+
+def test_multimeter_mode_cli_overrides_profile(monkeypatch):
+    """Passing --multimeter-mode overrides profile value."""
+    tc_instance = MagicMock()
+    tc_cls = MagicMock(return_value=tc_instance)
+    dummy_module = types.SimpleNamespace(TestController=tc_cls)
+    monkeypatch.setitem(sys.modules, "AlIonBatteryTestSoftware", dummy_module)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "MAIN.py",
+            "--profile",
+            "YUASA_CUSTOM1",
+            "--multimeter-mode",
+            "voltage",
+        ],
+    )
+
+    MAIN.main()
+
+    tc_cls.assert_called_once()
+    tc_instance.custom_test.assert_called_once()
+    assert tc_instance.custom_test.call_args.kwargs["multimeter_mode"] == "voltage"


### PR DESCRIPTION
## Summary
- add a unit test that validate_required_keys raises when required parameters are missing
- ensure CLI `--multimeter-mode` argument overrides profile value

## Testing
- `python -m py_compile *.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f31b7b3788325a3f2f320ab52c203